### PR TITLE
Added LRU cache of fstream objects.

### DIFF
--- a/cpp/ev3dev.cpp
+++ b/cpp/ev3dev.cpp
@@ -136,17 +136,14 @@ std::ofstream &ofstream_open(const std::string &path)
   std::ofstream &file = ofstream_cache[path];
   if (!file.is_open())
   {
-    // Don't buffer writes. Also saves a bit of memory.
+    // Don't buffer writes to avoid latency. Also saves a bit of memory.
     file.rdbuf()->pubsetbuf(NULL, 0);
     file.open(path);
   } 
   else 
   {
-    // If something happened (like reaching EOF), clear the error state.
-    if (!file.good())
-    {
-      file.clear();
-    }
+    // Clear the error bits in case something happened.
+    file.clear();
   }
   return file;
 }
@@ -161,11 +158,8 @@ std::ifstream &ifstream_open(const std::string &path)
   }
   else 
   {
-    // If something happened (like reaching EOF), clear the error state.
-    if (!file.good())
-    {
-      file.clear();
-    }
+    // Clear the flags bits in case something happened (like reaching EOF).
+    file.clear();
     file.seekg(0, std::ios::beg);
   }
   return file;

--- a/cpp/ev3dev.cpp
+++ b/cpp/ev3dev.cpp
@@ -32,13 +32,10 @@
 #include <algorithm>
 #include <system_error>
 #include <mutex>
-#include <dirent.h>
 #include <string.h>
 
-#include <cstdio>
-
+#include <dirent.h>
 #include <sys/mman.h>
-#include <sys/ioctl.h>
 #include <fcntl.h>
 #include <stdlib.h>
 
@@ -139,6 +136,8 @@ std::ofstream &ofstream_open(const std::string &path)
   std::ofstream &file = ofstream_cache[path];
   if (!file.is_open())
   {
+    // Don't buffer writes. Also saves a bit of memory.
+    file.rdbuf()->pubsetbuf(NULL, 0);
     file.open(path);
   } 
   else 
@@ -172,7 +171,7 @@ std::ifstream &ifstream_open(const std::string &path)
   return file;
 }
 
-}
+} // namespace
 
 //-----------------------------------------------------------------------------
 

--- a/cpp/ev3dev.h
+++ b/cpp/ev3dev.h
@@ -67,7 +67,7 @@ public:
   bool connect(const std::string &dir,
                const std::string &pattern,
                const std::map<std::string,
-                              std::set<std::string>> match) noexcept;
+                              std::set<std::string>> &match) noexcept;
   inline bool connected() const { return !_path.empty(); }
 
   int         device_index() const;


### PR DESCRIPTION
Hi ev3dev, first of all, thanks for putting together an awesome set of tools. This is exactly what I was hoping to find!

This PR implements a small cache of file handles for the C++ language bindings. This is discussed in issue #12. This is important to me because I'm trying to build some pretty stiff controllers. In this situation, the lower the latency (and higher the sample rate) the better.

 I think that the cache should hopefully alleviate the concerns mentioned in discussion on #12 regarding caching file handles consuming too many OS resources. The global LRU cache guarantees that there will only be < FILE_CACHE_SIZE file handles open at once. I think that this PR should basically make the cases that care about performance faster (reading/writing a few attributes very frequently in a tight loop) while keeping similar performance/resource consumption for other programs.

I benchmarked a program that reads the same attribute repeatedly in a tight loop:

Uncached:

    real    0m16.823s
    user    0m5.850s
    sys     0m9.750s

Cached:

    real    0m2.842s
    user    0m1.610s
    sys     0m1.100s