### PR TITLE
[cpp] Driver names for color, infrared, and ultrasound sensors have changed

### DIFF
--- a/cpp/ev3dev.cpp
+++ b/cpp/ev3dev.cpp
@@ -421,10 +421,10 @@ std::string device::get_attr_from_set(const std::string &name) const
 //-----------------------------------------------------------------------------
 
 const sensor::sensor_type sensor::ev3_touch       { "lego-ev3-touch" };
-const sensor::sensor_type sensor::ev3_color       { "ev3-uart-29" };
-const sensor::sensor_type sensor::ev3_ultrasonic  { "ev3-uart-30" };
-const sensor::sensor_type sensor::ev3_gyro        { "ev3-uart-32" };
-const sensor::sensor_type sensor::ev3_infrared    { "ev3-uart-33" };
+const sensor::sensor_type sensor::ev3_color       { "lego-ev3-uart-29" };
+const sensor::sensor_type sensor::ev3_ultrasonic  { "lego-ev3-uart-30" };
+const sensor::sensor_type sensor::ev3_gyro        { "lego-ev3-uart-32" };
+const sensor::sensor_type sensor::ev3_infrared    { "lego-ev3-uart-33" };
   
 const sensor::sensor_type sensor::nxt_touch       { "lego-nxt-touch" };
 const sensor::sensor_type sensor::nxt_light       { "lego-nxt-light" };


### PR DESCRIPTION
In the latest kernel driver names for color, infrared, and ultrasonic sensors have apparently changed. See ddemidov/ev3dev-lang-python#2.