### PR TITLE
[cpp] Transfer the C++ bindings to the auto-generation system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ js/bin/*
 /autogen/node_modules
 /autogen/npm-debug.log
 *.orig
+*.swp

--- a/autogen/autogen-list.json
+++ b/autogen/autogen-list.json
@@ -1,4 +1,7 @@
 {
+    "cpp": [
+        "cpp/ev3dev.h"
+    ],
     "js": [
         "js/extras.ts",
         "js/motor.ts",

--- a/autogen/autogen.js
+++ b/autogen/autogen.js
@@ -12,6 +12,7 @@ var autogenFenceComments = {
     '.ts': { start: cStyleAutogenStart, end: cStyleAutogenEnd },
     '.vala': { start: cStyleAutogenStart, end: cStyleAutogenEnd },
     '.cpp': { start: cStyleAutogenStart, end: cStyleAutogenEnd },
+    '.h': { start: cStyleAutogenStart, end: cStyleAutogenEnd },
     //XML-style regex here: http://regex101.com/r/cN6gE4
     '.md': { start: /<!--\s*~autogen *([\w-]+) *((\s*[\w\."']+>[\w\.]+)*)\s*-->/, end: "<!-- ~autogen -->" },
     //Lua regex: http://regex101.com/r/mI4gL1

--- a/autogen/templates/cpp_generic-get-set.liquid
+++ b/autogen/templates/cpp_generic-get-set.liquid
@@ -1,12 +1,12 @@
-{% for prop in currentClass.systemProperties %}{% 
+{% for prop in currentClass.systemProperties %}{%
   assign cppName = prop.name | downcase | underscore_spaces %}{%
   unless prop.type contains 'array' %}{%
-    assign type = prop.type %}{%    
-    assign attr = type %}{%    
+    assign type = prop.type %}{%
+    assign attr = type %}{%
     if type == 'string' %}{%
       assign type = 'std::string' %}{%
     endif %}{%
     if prop.readAccess == true %}  {{ type }} {{ cppName }}() const { return get_attr_{{ attr }}("{{ prop.systemName }}"); }
 {% endif %}{%if prop.writeAccess == true %}  void set_{{ cppName }}({{ type }} v) { set_attr_{{ attr }}("{{ prop.systemName }}", v); }
-    {% endif %}{% endunless %}
+{% endif %}{% endunless %}
 {% endfor %}

--- a/autogen/templates/cpp_generic-get-set.liquid
+++ b/autogen/templates/cpp_generic-get-set.liquid
@@ -6,13 +6,7 @@
     if type == 'string' %}{%
       assign type = 'std::string' %}{%
     endif %}{%
-    if prop.readAccess == true        
-%}    {{ type }} {{ cppName }} const { return get_attr_{{ attr }}("{{ prop.systemName }}"); }
-    {% endif %}{%
-    if prop.writeAccess == true %}
-    void set_{{ cppName }}({{ type }} v) { set_attr_{{ attr }}("{{ prop.systemName }}", v); }
-    {% endif %}
-    {%
-  endunless %}
-  
+    if prop.readAccess == true %}  {{ type }} {{ cppName }}() const { return get_attr_{{ attr }}("{{ prop.systemName }}"); }
+{% endif %}{%if prop.writeAccess == true %}  void set_{{ cppName }}({{ type }} v) { set_attr_{{ attr }}("{{ prop.systemName }}", v); }
+    {% endif %}{% endunless %}
 {% endfor %}

--- a/autogen/templates/cpp_generic-get-set.liquid
+++ b/autogen/templates/cpp_generic-get-set.liquid
@@ -1,12 +1,18 @@
 {% for prop in currentClass.systemProperties %}{%
   assign cppName = prop.name | downcase | underscore_spaces %}{%
-  if prop.type contains 'array' %}  mode_set {{ cppName }}() const { return get_attr_set("{{ prop.systemName }}"); }
-{% else %}{%
+  if prop.type contains 'array' %}
+    mode_set {{ cppName }}() const { return get_attr_set("{{ prop.systemName }}"); }{%
+  else %}{%
     assign type = prop.type %}{%
     assign attr = type %}{%
     if type == 'string' %}{%
       assign type = 'std::string' %}{%
     endif %}{%
-    if prop.readAccess == true %}  {{ type }} {{ cppName }}() const { return get_attr_{{ attr }}("{{ prop.systemName }}"); }
-{% endif %}{%if prop.writeAccess == true %}  void set_{{ cppName }}({{ type }} v) { set_attr_{{ attr }}("{{ prop.systemName }}", v); }
-{% endif %}{% endif %}{% endfor %}
+    if prop.readAccess == true %}
+    {{ type }} {{ cppName }}() const { return get_attr_{{ attr }}("{{ prop.systemName }}"); }{%
+    endif %}{%
+    if prop.writeAccess == true %}
+    void set_{{ cppName }}({{ type }} v) { set_attr_{{ attr }}("{{ prop.systemName }}", v); }{%
+    endif %}{%
+  endif %}{%
+endfor %}

--- a/autogen/templates/cpp_generic-get-set.liquid
+++ b/autogen/templates/cpp_generic-get-set.liquid
@@ -1,0 +1,18 @@
+{% for prop in currentClass.systemProperties %}{% 
+  assign cppName = prop.name | downcase | underscore_spaces %}{%
+  unless prop.type contains 'array' %}{%
+    assign type = prop.type %}{%    
+    assign attr = type %}{%    
+    if type == 'string' %}{%
+      assign type = 'std::string' %}{%
+    endif %}{%
+    if prop.readAccess == true        
+%}    {{ type }} {{ cppName }} const { return get_attr_{{ attr }}("{{ prop.systemName }}"); }
+    {% endif %}{%
+    if prop.writeAccess == true %}
+    void set_{{ cppName }}({{ type }} v) { set_attr_{{ attr }}("{{ prop.systemName }}", v); }
+    {% endif %}
+    {%
+  endunless %}
+  
+{% endfor %}

--- a/autogen/templates/cpp_generic-get-set.liquid
+++ b/autogen/templates/cpp_generic-get-set.liquid
@@ -1,6 +1,7 @@
 {% for prop in currentClass.systemProperties %}{%
   assign cppName = prop.name | downcase | underscore_spaces %}{%
-  unless prop.type contains 'array' %}{%
+  if prop.type contains 'array' %}  mode_set {{ cppName }}() const { return get_attr_set("{{ prop.systemName }}"); }
+{% else %}{%
     assign type = prop.type %}{%
     assign attr = type %}{%
     if type == 'string' %}{%
@@ -8,5 +9,4 @@
     endif %}{%
     if prop.readAccess == true %}  {{ type }} {{ cppName }}() const { return get_attr_{{ attr }}("{{ prop.systemName }}"); }
 {% endif %}{%if prop.writeAccess == true %}  void set_{{ cppName }}({{ type }} v) { set_attr_{{ attr }}("{{ prop.systemName }}", v); }
-{% endif %}{% endunless %}
-{% endfor %}
+{% endif %}{% endif %}{% endfor %}

--- a/cpp/Makefile
+++ b/cpp/Makefile
@@ -19,7 +19,7 @@ remote_control-test: $(OBJ) remote_control-test.o
 
 drive-test: $(OBJ) drive-test.o
 	$(CC) -o $@ $^ $(CFLAGS) $(CCFLAGS) $(LIBS) -lpthread
-	
+
 button-test: $(OBJ) button-test.o
 	$(CC) -o $@ $^ $(CFLAGS) $(CCFLAGS) $(LIBS)
 

--- a/cpp/Makefile
+++ b/cpp/Makefile
@@ -3,7 +3,7 @@ CFLAGS=-O2 -march=armv5
 CCFLAGS=-std=c++11 -D_GLIBCXX_USE_NANOSLEEP
 DEPS=ev3dev.h
 OBJ=ev3dev.o
-LIBS=-lstdc++
+LIBS=-lstdc++ -lm
 
 %.o: %.cpp $(DEPS)
 	$(CC) -c -o $@ $< $(CFLAGS) $(CCFLAGS)

--- a/cpp/drive-test.cpp
+++ b/cpp/drive-test.cpp
@@ -110,8 +110,8 @@ void control::drive(int speed, int time)
 
   _state = state_driving;
 
-  _motor_left .run();
-  _motor_right.run();
+  _motor_left .start();
+  _motor_right.start();
 
   if (time > 0)
   {
@@ -146,8 +146,8 @@ void control::turn(int direction)
 
   _state = state_turning;
 
-  _motor_left .run();
-  _motor_right.run();
+  _motor_left .start();
+  _motor_right.start();
 
   while (_motor_left.running() || _motor_right.running())
     this_thread::sleep_for(chrono::milliseconds(10));

--- a/cpp/drive-test.cpp
+++ b/cpp/drive-test.cpp
@@ -95,8 +95,8 @@ void control::drive(int speed, int time)
     _motor_left .set_run_mode(motor::run_mode_time);
     _motor_right.set_run_mode(motor::run_mode_time);
     
-    _motor_left .set_time_setpoint(time);
-    _motor_right.set_time_setpoint(time);
+    _motor_left .set_time_sp(time);
+    _motor_right.set_time_sp(time);
   }
   else
   {
@@ -104,9 +104,9 @@ void control::drive(int speed, int time)
     _motor_right.set_run_mode(motor::run_mode_forever);
   }
   
-  _motor_left.set_duty_cycle_setpoint(-speed);
+  _motor_left.set_duty_cycle_sp(-speed);
   
-  _motor_right.set_duty_cycle_setpoint(-speed);
+  _motor_right.set_duty_cycle_sp(-speed);
   
   _state = state_driving;
   
@@ -133,16 +133,16 @@ void control::turn(int direction)
   _motor_left.set_run_mode(motor::run_mode_position);
   //_motor_left.set_position_mode(motor::position_mode_relative);
   _motor_left.set_position(0);
-  _motor_left .set_position_setpoint(direction);
+  _motor_left .set_position_sp(direction);
   //_motor_left.set_regulation_mode(motor::mode_on);
-  _motor_left.set_duty_cycle_setpoint(50);
+  _motor_left.set_duty_cycle_sp(50);
 
   _motor_right.set_run_mode(motor::run_mode_position);
   //_motor_right.set_position_mode(motor::position_mode_relative);
   _motor_right.set_position(0);
-  _motor_right.set_position_setpoint(-direction);
+  _motor_right.set_position_sp(-direction);
   //_motor_right.set_regulation_mode(motor::mode_on);
-  _motor_right.set_duty_cycle_setpoint(50);
+  _motor_right.set_duty_cycle_sp(50);
   
   _state = state_turning;
 

--- a/cpp/ev3dev-lang-demo.cpp
+++ b/cpp/ev3dev-lang-demo.cpp
@@ -173,19 +173,19 @@ void motor_action(motor &m)
          << "r(e)gulation mode   [" << m.regulation_mode()   << "]" << endl;
     
     if (m.regulation_mode()==m.mode_on)
-      cout << "pulses/sec (s)etpoint (" << m.pulses_per_second_setpoint() << ")" << endl;
+      cout << "pulses/sec (s)etpoint (" << m.pulses_per_second_sp() << ")" << endl;
     else
-      cout << "duty cycle (s)etpoint (" << m.duty_cycle_setpoint() << ")" << endl;
+      cout << "duty cycle (s)etpoint (" << m.duty_cycle_sp() << ")" << endl;
 
     if (m.run_mode()==m.run_mode_position)
     {
-      cout << "position (m)ode     [" << m.position_mode()     << "]" << endl
-           << "(p)osition setpoint (" << m.position_setpoint() << ")" << endl
-           << "ramp (u)p           (" << m.ramp_up()           << ")" << endl
-           << "ramp (d)own         (" << m.ramp_down()         << ")" << endl;
+      cout << "position (m)ode      [" << m.position_mode() << "]" << endl
+           << "(p)osition setpoint  (" << m.position_sp()   << ")" << endl
+           << "ramp (u)p setpoint   (" << m.ramp_up_sp()    << ")" << endl
+           << "ramp (d)own setpoint (" << m.ramp_down_sp()  << ")" << endl;
     }
     else if (m.run_mode()==m.run_mode_time)
-      cout << "(t)ime setpoint     (" << m.time_setpoint()     << ")" << endl;
+      cout << "(t)ime setpoint      (" << m.time_sp()       << ")" << endl;
     
     cout << endl
          << "(0) reset position" << endl
@@ -225,11 +225,11 @@ void motor_action(motor &m)
     case 's':
       if (m.regulation_mode()==m.mode_on)
       {
-        cout << "pulses/sec: "; cin >> new_value; m.set_pulses_per_second_setpoint(new_value); cout << endl;
+        cout << "pulses/sec: "; cin >> new_value; m.set_pulses_per_second_sp(new_value); cout << endl;
       }
       else
       {
-        cout << "duty cycle: "; cin >> new_value; m.set_duty_cycle_setpoint(new_value); cout << endl;
+        cout << "duty cycle: "; cin >> new_value; m.set_duty_cycle_sp(new_value); cout << endl;
       }
       break;
     case 'm':
@@ -242,25 +242,25 @@ void motor_action(motor &m)
     case 'p':
       if (m.run_mode()==m.run_mode_position)
       {
-        cout << "position: "; cin >> new_value; m.set_position_setpoint(new_value); cout << endl;
+        cout << "position: "; cin >> new_value; m.set_position_sp(new_value); cout << endl;
       }
       break;
     case 'u':
       if (m.run_mode()==m.run_mode_position)
       {
-        cout << "ramp up: "; cin >> new_value; m.set_ramp_up(new_value); cout << endl;
+        cout << "ramp up: "; cin >> new_value; m.set_ramp_up_sp(new_value); cout << endl;
       }
       break;
     case 'd':
       if (m.run_mode()==m.run_mode_position)
       {
-        cout << "ramp down: "; cin >> new_value; m.set_ramp_down(new_value); cout << endl;
+        cout << "ramp down: "; cin >> new_value; m.set_ramp_down_sp(new_value); cout << endl;
       }
       break;
     case 't':
       if (m.run_mode()==m.run_mode_time)
       {
-        cout << "time: "; cin >> new_value; m.set_time_setpoint(new_value); cout << endl;
+        cout << "time: "; cin >> new_value; m.set_time_sp(new_value); cout << endl;
       }
       break;
     case '0':

--- a/cpp/ev3dev-lang-demo.cpp
+++ b/cpp/ev3dev-lang-demo.cpp
@@ -270,7 +270,7 @@ void motor_action(motor &m)
       m.reset();
       break;
     case '!':
-      m.run(!running);
+      m.set_run(!running);
       break;
     }
   }

--- a/cpp/ev3dev-lang-demo.cpp
+++ b/cpp/ev3dev-lang-demo.cpp
@@ -132,7 +132,7 @@ void sensor_menu()
       sensor &s = arrSensors[i];
       if (s.connected())
       {
-        cout << "(" << i+1 << ") " << s.type_name() << " (device " << s.device_name()
+        cout << "(" << i+1 << ") " << s.type_name() << " (device " << s.driver_name()
              << ", port " << s.port_name() << ", mode " << s.mode() << ")" << endl;
       }
     }

--- a/cpp/ev3dev-lang-demo.cpp
+++ b/cpp/ev3dev-lang-demo.cpp
@@ -29,7 +29,7 @@ using namespace ev3dev;
 
 void print_values(sensor &s)
 {
-  auto dp = s.dp();
+  auto dp = s.decimals();
   unsigned m = s.num_values();
   for (unsigned i=0; i<m; ++i)
   {
@@ -132,7 +132,7 @@ void sensor_menu()
       sensor &s = arrSensors[i];
       if (s.connected())
       {
-        cout << "(" << i+1 << ") " << s.type_name() << " (type " << s.type()
+        cout << "(" << i+1 << ") " << s.type_name() << " (device " << s.device_name()
              << ", port " << s.port_name() << ", mode " << s.mode() << ")" << endl;
       }
     }

--- a/cpp/ev3dev-lang-demo.cpp
+++ b/cpp/ev3dev-lang-demo.cpp
@@ -288,7 +288,6 @@ void motor_action(dc_motor &m)
     cout << endl
          << "*** dc motor (" << m.port_name() << ") actions ***" << endl
          << endl
-         << "(c)ommand      [" << m.command()      << "]" << endl
          << "(d)uty cycle   (" << m.duty_cycle()   << ")" << endl
          << "(r)amp down ms (" << m.ramp_down_ms() << ")" << endl
          << "ramp (u)p ms   (" << m.ramp_up_ms()   << ")" << endl

--- a/cpp/ev3dev-lang-demo.cpp
+++ b/cpp/ev3dev-lang-demo.cpp
@@ -59,7 +59,7 @@ void sensor_action(sensor &s)
          << endl
          << "Choice: ";
     cin >> c;
-    
+
     switch (c)
     {
     case 's':
@@ -90,7 +90,7 @@ void sensor_action(sensor &s)
           char cc; cin >> cc;
           bStop = true;
         });
-       
+
         int value, lastValue = -99999;
         while (!bStop)
         {
@@ -119,14 +119,14 @@ void sensor_menu()
     { INPUT_3 },
     { INPUT_4 }
   };
-  
+
   char c = 0;
   do
   {
     cout << endl
          << "*** sensor menu ***" << endl
          << endl;
-    
+
     for (unsigned i=0; i<4; ++i)
     {
       sensor &s = arrSensors[i];
@@ -141,7 +141,7 @@ void sensor_menu()
     cout << endl
          << "Choice: ";
     cin >> c;
-    
+
     switch (c)
     {
     case '1':
@@ -161,7 +161,7 @@ void motor_action(motor &m)
   int new_value = 0;
   std::string new_mode;
   bool running = false;
-  
+
   do
   {
     cout << endl
@@ -171,7 +171,7 @@ void motor_action(motor &m)
          << "(r)un mode          [" << m.run_mode()          << "]" << endl
          << "st(o)p mode         [" << m.stop_mode()         << "]" << endl
          << "r(e)gulation mode   [" << m.regulation_mode()   << "]" << endl;
-    
+
     if (m.regulation_mode()==m.mode_on)
       cout << "pulses/sec (s)etpoint (" << m.pulses_per_second_sp() << ")" << endl;
     else
@@ -186,7 +186,7 @@ void motor_action(motor &m)
     }
     else if (m.run_mode()==m.run_mode_time)
       cout << "(t)ime setpoint      (" << m.time_sp()       << ")" << endl;
-    
+
     cout << endl
          << "(0) reset position" << endl
          << "(#) reset all" << endl
@@ -200,7 +200,7 @@ void motor_action(motor &m)
          << endl
          << "Choice: ";
     cin >> c;
-    
+
     switch (c)
     {
     case 'i':
@@ -282,7 +282,7 @@ void motor_action(dc_motor &m)
   char c = 0;
   int new_value = 0;
   std::string new_mode;
-  
+
   do
   {
     cout << endl
@@ -297,7 +297,7 @@ void motor_action(dc_motor &m)
          << endl
          << "Choice: ";
     cin >> c;
-    
+
     switch (c)
     {
     case 'c':
@@ -328,7 +328,7 @@ void motor_action(servo_motor &m)
   char c = 0;
   int new_value = 0;
   std::string new_mode;
-  
+
   do
   {
     cout << endl
@@ -345,7 +345,7 @@ void motor_action(servo_motor &m)
          << endl
          << "Choice: ";
     cin >> c;
-    
+
     switch (c)
     {
     case 'c':
@@ -396,14 +396,14 @@ void motor_menu()
     { OUTPUT_C },
     { OUTPUT_D }
   };
-  
+
   char c = 0;
   do
   {
     cout << endl
          << "*** motor menu ***" << endl
          << endl;
-    
+
     for (unsigned i=0; i<4; ++i)
     {
       motor &m = arrMotors[i];
@@ -425,7 +425,7 @@ void motor_menu()
     cout << endl
          << "Choice: ";
     cin >> c;
-    
+
     switch (c)
     {
     case '1':
@@ -463,7 +463,7 @@ void led_action(const char *name, led &l)
          << endl
          << "Choice: ";
     cin >> c;
-    
+
     switch (c)
     {
     case '0':
@@ -492,7 +492,7 @@ void led_action(const char *name, led &l)
             cout << *it << " ";
         }
         cout << endl << endl << "choice: ";
-       
+
         cin >> t;
         if (!t.empty())
           l.set_trigger(t);
@@ -518,7 +518,7 @@ void led_menu()
          << "(2) green:right" << endl
          << "(3) red:left"    << endl
          << "(4) red:right"   << endl;
-    
+
     for (unsigned i=0; i<4; ++i)
     {
       if (arrPortLEDs[i].connected())
@@ -526,13 +526,13 @@ void led_menu()
         cout << "(" << 5+i << ") out" << static_cast<char>('A'+i) << endl;
       }
     }
-    
+
     cout << endl
          << "(b)ack"          << endl
          << endl
          << "Choice: ";
     cin >> c;
-    
+
     switch (c)
     {
     case '1':
@@ -583,7 +583,7 @@ void button_menu()
          << endl
          << "Choice: ";
     cin >> c;
-    
+
     switch (c)
     {
     case '1':
@@ -629,7 +629,7 @@ void sound_menu()
          << endl
          << "Choice: ";
     cin >> c;
-    
+
     switch (c)
     {
     case 'e':
@@ -688,7 +688,7 @@ void battery_menu()
          << endl
          << "Choice: ";
     cin >> c;
-    
+
     switch (c)
     {
     case 'v':
@@ -705,14 +705,14 @@ void battery_menu()
 void lcd_menu()
 {
   lcd l;
-  
+
   if (!l.available())
   {
     cout << endl
          << "###error: lcd not available ###" << endl;
     return;
   }
-  
+
   char c = 0;
   do
   {
@@ -727,7 +727,7 @@ void lcd_menu()
          << endl
          << "Choice: ";
     cin >> c;
-    
+
     switch (c)
     {
     case 'i':
@@ -766,7 +766,7 @@ void main_menu()
          << endl
          << "Choice: ";
     cin >> c;
-    
+
     switch (c)
     {
     case 's':
@@ -798,6 +798,6 @@ void main_menu()
 int main()
 {
   main_menu();
-  
+
   return 0;
 }

--- a/cpp/ev3dev-lang-test.cpp
+++ b/cpp/ev3dev-lang-test.cpp
@@ -52,19 +52,19 @@ void test_motor(const char *name)
     cout << endl
          << "Found " << name << " motor on port " << m.port_name() << endl
          << endl;
-    
+
     cout << "  Current state is " << m.state() << endl
          << "    duty_cycle: " << m.duty_cycle() << endl
          << "    pulses_per_second: " << m.pulses_per_second() << endl << endl
          << "  Current run mode is " << m.run_mode() << endl
          << "    stop mode: " << m.stop_mode() << endl
          << "    regulation mode: " << m.regulation_mode() << endl << endl;
-    
+
     if (m.regulation_mode()==m.mode_on)
       cout << "  pulses_per_second setpoint is " << m.pulses_per_second_sp() << endl;
     else
       cout << "  duty_cycle setpoint is " << m.duty_cycle_sp() << endl;
-    
+
     if (m.run_mode()==m.run_mode_time)
       cout << "  Time setpoint is " << m.time_sp() << endl;
     if (m.run_mode()==m.run_mode_position)
@@ -83,7 +83,7 @@ void test_dc_motor()
     cout << endl
          << "Found dc motor on port " << m.port_name() << endl
          << endl;
-    
+
     cout << "  Current command is " << m.command() << endl
          << "    duty_cycle:   " << m.duty_cycle() << endl
          << "    ramp_up_ms:   " << m.ramp_up_ms() << endl << endl
@@ -102,7 +102,7 @@ void test_servo_motor()
     cout << endl
          << "Found servo motor on port " << m.port_name() << endl
          << endl;
-    
+
     cout << "  Current command is " << m.command() << endl
          << "    position:     " << m.position() << endl
          << "    rate:         " << m.rate() << endl
@@ -124,15 +124,15 @@ int main()
   test_sensor<gyro_sensor>("gyro");
   test_sensor<infrared_sensor>("infrared");
   test_sensor<i2c_sensor>("i2c");
-  
+
   cout << endl;
-  
+
   test_motor<medium_motor>("medium");
   test_motor<large_motor>("large");
-  
+
   test_dc_motor();
   test_servo_motor();
-  
+
   const vector<string> outPortLEDs {
     "ev3::outA",
     "ev3::outB",
@@ -148,16 +148,16 @@ int main()
       cout << "Trigger of " << portName << " led is " << l.trigger() << endl << endl;
     }
   }
-  
+
   cout << "Brightness of left green led is " << led::green_left.brightness() << endl;
   cout << "Trigger of right red led is " << led::red_right.trigger() << endl << endl;
-  
+
   cout << "Beeping..." << endl << endl; sound::beep();
-  
+
   cout << "Battery voltage is " << power_supply::battery.voltage_volts() << " V" << endl;
   cout << "Battery current is " << power_supply::battery.current_amps() << " A" <<  endl;
-  
+
   cout << endl;
-  
+
   return 0;
 }

--- a/cpp/ev3dev-lang-test.cpp
+++ b/cpp/ev3dev-lang-test.cpp
@@ -61,15 +61,15 @@ void test_motor(const char *name)
          << "    regulation mode: " << m.regulation_mode() << endl << endl;
     
     if (m.regulation_mode()==m.mode_on)
-      cout << "  pulses_per_second setpoint is " << m.pulses_per_second_setpoint() << endl;
+      cout << "  pulses_per_second setpoint is " << m.pulses_per_second_sp() << endl;
     else
-      cout << "  duty_cycle setpoint is " << m.duty_cycle_setpoint() << endl;
+      cout << "  duty_cycle setpoint is " << m.duty_cycle_sp() << endl;
     
     if (m.run_mode()==m.run_mode_time)
-      cout << "  Time setpoint is " << m.time_setpoint() << endl;
+      cout << "  Time setpoint is " << m.time_sp() << endl;
     if (m.run_mode()==m.run_mode_position)
-      cout << "  Position setpoint is " << m.position_setpoint() << endl;
-    cout << "    ramp up: " << m.ramp_up()  << "   ramp down: " << m.ramp_down() << endl<< endl;
+      cout << "  Position setpoint is " << m.position_sp() << endl;
+    cout << "    ramp up: " << m.ramp_up_sp()  << "   ramp down: " << m.ramp_down_sp() << endl << endl;
   }
   else
     cout << "No " << name << " motor found" << endl;

--- a/cpp/ev3dev-lang-test.cpp
+++ b/cpp/ev3dev-lang-test.cpp
@@ -84,7 +84,7 @@ void test_dc_motor()
          << "Found dc motor on port " << m.port_name() << endl
          << endl;
 
-    cout << "  Current command is " << m.command() << endl
+    cout << "  Current parameters" << endl
          << "    duty_cycle:   " << m.duty_cycle() << endl
          << "    ramp_up_ms:   " << m.ramp_up_ms() << endl << endl
          << "    ramp_down_ms: " << m.ramp_down_ms() << endl << endl

--- a/cpp/ev3dev.cpp
+++ b/cpp/ev3dev.cpp
@@ -456,24 +456,23 @@ bool sensor::connect(const std::map<std::string, std::set<std::string>> &match) 
   {
     if (device::connect(_strClassDir, _strPattern, match))
     {
-      init_members(true);
+      init_members();
       return true;
     }
   }
   catch (...) { }
   
   _path.clear();
-  _port_name.clear();
-  _type.clear();
   
   return false;
 }
 
 //-----------------------------------------------------------------------------
 
-const std::string &sensor::type_name() const
+std::string sensor::type_name() const
 {
-  if (_type.empty())
+  auto type = device_name();
+  if (type.empty())
   {
     static const std::string s("<none>");
     return s;
@@ -492,11 +491,11 @@ const std::string &sensor::type_name() const
     { nxt_i2c_sensor,  "I2C sensor" },
   };
   
-  auto s = lookup_table.find(_type);
+  auto s = lookup_table.find(type);
   if (s != lookup_table.end())
     return s->second;
   
-  return _type;
+  return type;
 }
 
 //-----------------------------------------------------------------------------
@@ -535,15 +534,9 @@ const mode_type &sensor::mode() const
 
 //-----------------------------------------------------------------------------
 
-void sensor::init_members(bool bAll)
+void sensor::init_members()
 {
   using namespace std;
-
-  if (bAll)
-  {
-    _port_name = get_attr_string("port_name");
-    _type = get_attr_string("name");
-  }
 
   _mode    = get_attr_string("mode");
   _modes   = get_attr_set("modes");
@@ -564,7 +557,7 @@ void sensor::set_mode(const mode_type &mode_)
   if (mode_ != _mode)
   {
     set_attr_string("mode", mode_);
-    const_cast<sensor*>(this)->init_members(false);
+    const_cast<sensor*>(this)->init_members();
   }
 }
 

--- a/cpp/ev3dev.cpp
+++ b/cpp/ev3dev.cpp
@@ -421,10 +421,10 @@ std::string device::get_attr_from_set(const std::string &name) const
 //-----------------------------------------------------------------------------
 
 const sensor::sensor_type sensor::ev3_touch       { "lego-ev3-touch" };
-const sensor::sensor_type sensor::ev3_color       { "ev3-uart-29" };
-const sensor::sensor_type sensor::ev3_ultrasonic  { "ev3-uart-30" };
-const sensor::sensor_type sensor::ev3_gyro        { "ev3-uart-32" };
-const sensor::sensor_type sensor::ev3_infrared    { "ev3-uart-33" };
+const sensor::sensor_type sensor::ev3_color       { "lego-ev3-uart-29" };
+const sensor::sensor_type sensor::ev3_ultrasonic  { "lego-ev3-uart-30" };
+const sensor::sensor_type sensor::ev3_gyro        { "lego-ev3-uart-32" };
+const sensor::sensor_type sensor::ev3_infrared    { "lego-ev3-uart-33" };
 
 const sensor::sensor_type sensor::nxt_touch       { "lego-nxt-touch" };
 const sensor::sensor_type sensor::nxt_light       { "lego-nxt-light" };

--- a/cpp/ev3dev.cpp
+++ b/cpp/ev3dev.cpp
@@ -672,19 +672,11 @@ bool motor::connect(const std::map<std::string, std::set<std::string>> &match) n
   
   try
   {
-    if (device::connect(_strClassDir, _strPattern, match))
-    {
-      _port_name = get_attr_string("port_name");
-      _type = get_attr_string("type");
-
-      return true;
-    }
+    return device::connect(_strClassDir, _strPattern, match);
   }
   catch (...) { }
 
   _path.clear();
-  _port_name.clear();
-  _type.clear();
   
   return false;
 }

--- a/cpp/ev3dev.cpp
+++ b/cpp/ev3dev.cpp
@@ -59,7 +59,7 @@
 //-----------------------------------------------------------------------------
 
 namespace ev3dev {
-  
+
 namespace {
 
 // This class implements a small LRU cache. It assumes the number of elements
@@ -111,7 +111,7 @@ public:
 
 private:
   typedef typename std::list<item>::iterator iterator;
-  
+
   iterator find(const K &k)
   {
     return std::find_if(_items.begin(), _items.end(),
@@ -139,8 +139,8 @@ std::ofstream &ofstream_open(const std::string &path)
     // Don't buffer writes to avoid latency. Also saves a bit of memory.
     file.rdbuf()->pubsetbuf(NULL, 0);
     file.open(path);
-  } 
-  else 
+  }
+  else
   {
     // Clear the error bits in case something happened.
     file.clear();
@@ -156,7 +156,7 @@ std::ifstream &ifstream_open(const std::string &path)
   {
     file.open(path);
   }
-  else 
+  else
   {
     // Clear the flags bits in case something happened (like reaching EOF).
     file.clear();
@@ -177,10 +177,10 @@ bool device::connect(const std::string &dir,
   using namespace std;
 
   const size_t pattern_length = pattern.length();
-  
+
   struct dirent *dp;
   DIR *dfd;
-  
+
   if ((dfd = opendir(dir.c_str())) != nullptr)
   {
     while ((dp = readdir(dfd)) != nullptr)
@@ -190,7 +190,7 @@ bool device::connect(const std::string &dir,
         try
         {
           _path = dir + dp->d_name + '/';
-          
+
           bool bMatch = true;
           for (auto &m : match)
           {
@@ -205,22 +205,22 @@ bool device::connect(const std::string &dir,
               break;
             }
           }
-          
+
           if (bMatch) {
             closedir(dfd);
             return true;
           }
         }
         catch (...) { }
-        
+
         _path.clear();
       }
     }
-    
+
     closedir(dfd);
   }
 
-  return false;  
+  return false;
 }
 
 //-----------------------------------------------------------------------------
@@ -228,7 +228,7 @@ bool device::connect(const std::string &dir,
 int device::device_index() const
 {
   using namespace std;
-  
+
   if (_path.empty())
     throw system_error(make_error_code(errc::function_not_supported), "no device connected");
 
@@ -240,12 +240,12 @@ int device::device_index() const
     {
       if ((*it < '0') || (*it > '9'))
         break;
-      
+
       _device_index += (*it -'0') * f;
       f *= 10;
     }
   }
-  
+
   return _device_index;
 }
 
@@ -254,10 +254,10 @@ int device::device_index() const
 int device::get_attr_int(const std::string &name) const
 {
   using namespace std;
-  
+
   if (_path.empty())
     throw system_error(make_error_code(errc::function_not_supported), "no device connected");
-  
+
   ifstream &is = ifstream_open(_path + name);
   if (is.is_open())
   {
@@ -265,7 +265,7 @@ int device::get_attr_int(const std::string &name) const
     is >> result;
     return result;
   }
-  
+
   throw system_error(make_error_code(errc::no_such_device), _path+name);
 }
 
@@ -274,7 +274,7 @@ int device::get_attr_int(const std::string &name) const
 void device::set_attr_int(const std::string &name, int value)
 {
   using namespace std;
-  
+
   if (_path.empty())
     throw system_error(make_error_code(errc::function_not_supported), "no device connected");
 
@@ -284,7 +284,7 @@ void device::set_attr_int(const std::string &name, int value)
     os << value;
     return;
   }
-  
+
   throw system_error(make_error_code(errc::no_such_device), _path+name);
 }
 
@@ -293,7 +293,7 @@ void device::set_attr_int(const std::string &name, int value)
 std::string device::get_attr_string(const std::string &name) const
 {
   using namespace std;
-  
+
   if (_path.empty())
     throw system_error(make_error_code(errc::function_not_supported), "no device connected");
 
@@ -304,7 +304,7 @@ std::string device::get_attr_string(const std::string &name) const
     is >> result;
     return result;
   }
-  
+
   throw system_error(make_error_code(errc::no_such_device), _path+name);
 }
 
@@ -323,7 +323,7 @@ void device::set_attr_string(const std::string &name, const std::string &value)
     os << value;
     return;
   }
-  
+
   throw system_error(make_error_code(errc::no_such_device), _path+name);
 }
 
@@ -332,10 +332,10 @@ void device::set_attr_string(const std::string &name, const std::string &value)
 std::string device::get_attr_line(const std::string &name) const
 {
   using namespace std;
-  
+
   if (_path.empty())
     throw system_error(make_error_code(errc::function_not_supported), "no device connected");
-  
+
   ifstream &is = ifstream_open(_path + name);
   if (is.is_open())
   {
@@ -343,7 +343,7 @@ std::string device::get_attr_line(const std::string &name) const
     getline(is, result);
     return result;
   }
-  
+
   throw system_error(make_error_code(errc::no_such_device), _path+name);
 }
 
@@ -361,7 +361,7 @@ mode_set device::get_attr_set(const std::string &name,
   string t;
   do {
     pos = s.find(' ', last_pos);
-    
+
     if (pos != string::npos)
     {
       t = s.substr(last_pos, pos-last_pos);
@@ -369,7 +369,7 @@ mode_set device::get_attr_set(const std::string &name,
     }
     else
       t = s.substr(last_pos);
-    
+
     if (!t.empty())
     {
       if (*t.begin()=='[')
@@ -381,7 +381,7 @@ mode_set device::get_attr_set(const std::string &name,
       result.insert(t);
     }
   } while (pos!=string::npos);
-  
+
   return result;
 }
 
@@ -390,14 +390,14 @@ mode_set device::get_attr_set(const std::string &name,
 std::string device::get_attr_from_set(const std::string &name) const
 {
   using namespace std;
-  
+
   string s = get_attr_line(name);
-  
+
   size_t pos, last_pos = 0;
   string t;
   do {
     pos = s.find(' ', last_pos);
-    
+
     if (pos != string::npos)
     {
       t = s.substr(last_pos, pos-last_pos);
@@ -405,7 +405,7 @@ std::string device::get_attr_from_set(const std::string &name) const
     }
     else
       t = s.substr(last_pos);
-    
+
     if (!t.empty())
     {
       if (*t.begin()=='[')
@@ -414,7 +414,7 @@ std::string device::get_attr_from_set(const std::string &name) const
       }
     }
   } while (pos!=string::npos);
-  
+
   return { "none" };
 }
 
@@ -425,7 +425,7 @@ const sensor::sensor_type sensor::ev3_color       { "ev3-uart-29" };
 const sensor::sensor_type sensor::ev3_ultrasonic  { "ev3-uart-30" };
 const sensor::sensor_type sensor::ev3_gyro        { "ev3-uart-32" };
 const sensor::sensor_type sensor::ev3_infrared    { "ev3-uart-33" };
-  
+
 const sensor::sensor_type sensor::nxt_touch       { "lego-nxt-touch" };
 const sensor::sensor_type sensor::nxt_light       { "lego-nxt-light" };
 const sensor::sensor_type sensor::nxt_sound       { "lego-nxt-sound" };
@@ -453,7 +453,7 @@ bool sensor::connect(const std::map<std::string, std::set<std::string>> &match) 
 {
   static const std::string _strClassDir { SYS_ROOT "/class/lego-sensor/" };
   static const std::string _strPattern  { "sensor" };
-  
+
   try
   {
     if (device::connect(_strClassDir, _strPattern, match))
@@ -463,9 +463,9 @@ bool sensor::connect(const std::map<std::string, std::set<std::string>> &match) 
     }
   }
   catch (...) { }
-  
+
   _path.clear();
-  
+
   return false;
 }
 
@@ -479,7 +479,7 @@ std::string sensor::type_name() const
     static const std::string s("<none>");
     return s;
   }
-  
+
   static const std::map<sensor_type, const std::string> lookup_table {
     { ev3_touch,       "EV3 touch" },
     { ev3_color,       "EV3 color" },
@@ -492,11 +492,11 @@ std::string sensor::type_name() const
     { nxt_ultrasonic,  "NXT ultrasonic" },
     { nxt_i2c_sensor,  "I2C sensor" },
   };
-  
+
   auto s = lookup_table.find(type);
   if (s != lookup_table.end())
     return s->second;
-  
+
   return type;
 }
 
@@ -506,29 +506,29 @@ int sensor::value(unsigned index) const
 {
   if (index >= _nvalues)
     throw std::invalid_argument("index");
-    
+
   char svalue[7] = "value0";
   svalue[5] += index;
-  
+
   return get_attr_int(svalue);
 }
 
 //-----------------------------------------------------------------------------
-  
+
 float sensor::float_value(unsigned index) const
 {
   return value(index) * _dp_scale;
 }
 
 //-----------------------------------------------------------------------------
-  
+
 const mode_set &sensor::modes() const
 {
   return _modes;
 }
 
 //-----------------------------------------------------------------------------
-  
+
 const mode_type &sensor::mode() const
 {
   return _mode;
@@ -544,7 +544,7 @@ void sensor::init_members()
   _modes   = get_attr_set("modes");
   _nvalues = get_attr_int("num_values");
   _dp      = get_attr_int("decimals");
-  
+
   _dp_scale = 1.f;
   for (unsigned dp = _dp; dp; --dp)
   {
@@ -633,7 +633,7 @@ infrared_sensor::infrared_sensor(port_type port_) :
 }
 
 //-----------------------------------------------------------------------------
-  
+
 const motor::motor_type motor::motor_large  { "tacho"     };
 const motor::motor_type motor::motor_medium { "minitacho" };
 
@@ -643,7 +643,7 @@ const mode_type motor::mode_on  { "on"  };
 const mode_type motor::run_mode_forever  { "forever"  };
 const mode_type motor::run_mode_time     { "time"     };
 const mode_type motor::run_mode_position { "position" };
-  
+
 const mode_type motor::stop_mode_coast { "coast" };
 const mode_type motor::stop_mode_brake { "brake" };
 const mode_type motor::stop_mode_hold  { "hold"  };
@@ -671,7 +671,7 @@ bool motor::connect(const std::map<std::string, std::set<std::string>> &match) n
 {
   static const std::string _strClassDir { SYS_ROOT "/class/tacho-motor/" };
   static const std::string _strPattern  { "motor" };
-  
+
   try
   {
     return device::connect(_strClassDir, _strPattern, match);
@@ -679,7 +679,7 @@ bool motor::connect(const std::map<std::string, std::set<std::string>> &match) n
   catch (...) { }
 
   _path.clear();
-  
+
   return false;
 }
 
@@ -704,7 +704,7 @@ dc_motor::dc_motor(port_type port)
 
   connect(_strClassDir, _strPattern, {{ "port_name", { port }}});
 }
-  
+
 const std::string dc_motor::command_run       { "run" };
 const std::string dc_motor::command_brake     { "brake" };
 const std::string dc_motor::command_coast     { "coast" };
@@ -717,21 +717,21 @@ servo_motor::servo_motor(port_type port)
 {
   static const std::string _strClassDir { SYS_ROOT "/class/servo-motor/" };
   static const std::string _strPattern  { "motor" };
-  
+
   connect(_strClassDir, _strPattern, {{ "port_name", { port }}});
 }
-  
+
 const std::string servo_motor::command_run       { "run" };
 const std::string servo_motor::command_float     { "float" };
 const std::string servo_motor::polarity_normal   { "normal" };
 const std::string servo_motor::polarity_inverted { "inverted" };
-  
+
 //-----------------------------------------------------------------------------
 
 led::led(std::string name)
 {
   static const std::string _strClassDir { SYS_ROOT "/class/leds/" };
-  
+
   if (connect(_strClassDir, name, std::map<std::string, std::set<std::string>>()))
   {
     _max_brightness = get_attr_int("max_brightness");
@@ -776,10 +776,10 @@ power_supply power_supply::battery { "" };
 power_supply::power_supply(std::string name)
 {
   static const std::string _strClassDir { SYS_ROOT "/class/power_supply/" };
-  
+
   if (name.empty())
     name = "legoev3-battery";
-  
+
   connect(_strClassDir, name, std::map<std::string, std::set<std::string>>());
 }
 
@@ -847,7 +847,7 @@ void sound::play(const std::string &soundfile, bool bSynchronous)
   {
     cmd.append(" &");
   }
-  
+
   std::system(cmd.c_str());
 }
 
@@ -862,7 +862,7 @@ void sound::speak(const std::string &text, bool bSynchronous)
   {
     cmd.append(" &");
   }
-  
+
   std::system(cmd.c_str());
 }
 
@@ -871,7 +871,7 @@ void sound::speak(const std::string &text, bool bSynchronous)
 unsigned sound::volume()
 {
   unsigned result = 0;
-  
+
   std::ifstream is(SYS_SOUND "/volume");
   if (is.is_open())
   {
@@ -893,7 +893,7 @@ void sound::set_volume(unsigned v)
 }
 
 //-----------------------------------------------------------------------------
-  
+
 lcd::lcd() :
   _fb(nullptr),
   _fbsize(0),
@@ -904,7 +904,7 @@ lcd::lcd() :
 {
   init();
 }
- 
+
 //-----------------------------------------------------------------------------
 
 lcd::~lcd()
@@ -932,20 +932,20 @@ void lcd::init()
   int fbf = open("/dev/fb0", O_RDWR);
   if (fbf < 0)
     return;
-  
+
   fb_fix_screeninfo i;
   if (ioctl(fbf, FBIOGET_FSCREENINFO, &i) < 0)
     return;
-  
+
   _fbsize  = i.smem_len;
   _llength = i.line_length;
-  
+
   _fb = (unsigned char*)mmap(NULL, _fbsize, PROT_READ|PROT_WRITE, MAP_SHARED, fbf, 0);
   if (_fb == nullptr)
     return;
-  
+
 	fb_var_screeninfo v;
-  
+
   if (ioctl(fbf, FBIOGET_VSCREENINFO, &v) < 0)
     return;
 
@@ -954,7 +954,7 @@ void lcd::init()
   _bpp  = v.bits_per_pixel;
  #endif
 }
-  
+
 //-----------------------------------------------------------------------------
 
 void lcd::deinit()
@@ -963,7 +963,7 @@ void lcd::deinit()
   {
     munmap(_fb, 0);
   }
-  
+
   _fbsize = 0;
 }
 
@@ -975,7 +975,7 @@ remote_control::remote_control(unsigned channel) :
 {
   if ((channel >= 1) && (channel <=4))
     _channel = channel-1;
-  
+
   if (_sensor->connected())
     _sensor->set_mode(infrared_sensor::mode_ir_remote);
 }
@@ -988,7 +988,7 @@ remote_control::remote_control(infrared_sensor &ir, unsigned channel) :
 {
   if ((channel >= 1) && (channel <=4))
     _channel = channel-1;
-  
+
   if (_sensor->connected())
     _sensor->set_mode(infrared_sensor::mode_ir_remote);
 }
@@ -1012,7 +1012,7 @@ bool remote_control::process()
     _value = value;
     return true;
   }
-  
+
   return false;
 }
 
@@ -1021,7 +1021,7 @@ bool remote_control::process()
 void remote_control::on_value_changed(int value)
 {
   int new_state = 0;
-  
+
   switch (value)
   {
   case 1:
@@ -1058,32 +1058,32 @@ void remote_control::on_value_changed(int value)
     new_state = blue_up | blue_down;
     break;
   }
-  
+
   if (((new_state & red_up) != (_state & red_up)) &&
       static_cast<bool>(on_red_up))
     on_red_up(new_state & red_up);
-  
+
   if (((new_state & red_down) != (_state & red_down)) &&
       static_cast<bool>(on_red_down))
     on_red_down(new_state & red_down);
-  
+
   if (((new_state & blue_up) != (_state & blue_up)) &&
       static_cast<bool>(on_blue_up))
     on_blue_up(new_state & blue_up);
-  
+
   if (((new_state & blue_down) != (_state & blue_down)) &&
       static_cast<bool>(on_blue_down))
     on_blue_down(new_state & blue_down);
-  
+
   if (((new_state & beacon) != (_state & beacon)) &&
       static_cast<bool>(on_beacon))
     on_beacon(new_state & beacon);
-  
+
   _state = new_state;
 }
 
 //-----------------------------------------------------------------------------
-  
+
 } // namespace ev3dev
 
 //-----------------------------------------------------------------------------

--- a/cpp/ev3dev.h
+++ b/cpp/ev3dev.h
@@ -42,7 +42,7 @@
 namespace ev3dev {
 
 //-----------------------------------------------------------------------------
-  
+
 typedef std::string         device_type;
 typedef std::string         port_type;
 typedef std::string         mode_type;
@@ -56,7 +56,7 @@ const port_type INPUT_1  { "in1" };  //!< Sensor port 1
 const port_type INPUT_2  { "in2" };  //!< Sensor port 2
 const port_type INPUT_3  { "in3" };  //!< Sensor port 3
 const port_type INPUT_4  { "in4" };  //!< Sensor port 4
- 
+
 const port_type OUTPUT_AUTO;         //!< Automatic output selection
 const port_type OUTPUT_A { "outA" }; //!< Motor port A
 const port_type OUTPUT_B { "outB" }; //!< Motor port B
@@ -75,7 +75,7 @@ public:
   inline bool connected() const { return !_path.empty(); }
 
   int         device_index() const;
-  
+
   int         get_attr_int   (const std::string &name) const;
   void        set_attr_int   (const std::string &name,
                               int value);
@@ -86,9 +86,9 @@ public:
   std::string get_attr_line  (const std::string &name) const;
   mode_set    get_attr_set   (const std::string &name,
                               std::string *pCur = nullptr) const;
-  
+
   std::string get_attr_from_set(const std::string &name) const;
-  
+
 protected:
   std::string _path;
   mutable int _device_index = -1;
@@ -100,22 +100,22 @@ class sensor : protected device
 {
 public:
   typedef device_type sensor_type;
-  
+
   static const sensor_type ev3_touch;
   static const sensor_type ev3_color;
   static const sensor_type ev3_ultrasonic;
   static const sensor_type ev3_gyro;
   static const sensor_type ev3_infrared;
-  
+
   static const sensor_type nxt_touch;
   static const sensor_type nxt_light;
   static const sensor_type nxt_sound;
   static const sensor_type nxt_ultrasonic;
   static const sensor_type nxt_i2c_sensor;
-  
+
   sensor(port_type);
   sensor(port_type, const std::set<sensor_type>&);
- 
+
   using device::connected;
   using device::device_index;
 
@@ -123,31 +123,31 @@ public:
   std::string device_name() const { return get_attr_string("device_name"); }
   std::string type_name()   const;
   std::string units()       const { return get_attr_string("units"); }
-  
+
   inline unsigned num_values()  const { return _nvalues; }
   inline unsigned decimals()    const { return _dp; }
-  
+
   int   value(unsigned index=0) const;
   float float_value(unsigned index=0) const;
-  
+
   const mode_set  &modes() const;
   const mode_type &mode()  const;
-  
+
   void set_mode(const mode_type&);
 
   void set_command(std::string v) { set_attr_string("command", v); }
-  
+
 protected:
   sensor() {}
 
   bool connect(const std::map<std::string, std::set<std::string>>&) noexcept;
   void init_members();
-  
+
 protected:
   unsigned _nvalues = 0;
   unsigned _dp = 0;
   float    _dp_scale = 1.f;
-  
+
   mode_set    _modes;
   mode_type   _mode;
 };
@@ -159,7 +159,7 @@ class i2c_sensor : public sensor
 public:
   i2c_sensor(port_type port = INPUT_AUTO);
   i2c_sensor(port_type port, address_type address);
-  
+
   //~autogen cpp_generic-get-set classes.i2cSensor>currentClass
   std::string fw_version() const { return get_attr_string("fw_version"); }
 
@@ -187,7 +187,7 @@ class color_sensor : public sensor
 {
 public:
   color_sensor(port_type port_ = INPUT_AUTO);
-  
+
   static const mode_type mode_reflect;
   static const mode_type mode_ambient;
   static const mode_type mode_color;
@@ -213,7 +213,7 @@ class gyro_sensor : public sensor
 {
 public:
   gyro_sensor(port_type port_ = INPUT_AUTO);
-  
+
   static const mode_type mode_angle;
   static const mode_type mode_speed;
   static const mode_type mode_angle_and_speed;
@@ -237,16 +237,16 @@ class motor : protected device
 {
 public:
   typedef device_type motor_type;
-  
+
   motor(port_type);
   motor(port_type, const motor_type&);
-  
+
   static const motor_type motor_large;
   static const motor_type motor_medium;
-  
+
   static const mode_type mode_off;
   static const mode_type mode_on;
-    
+
   static const mode_type run_mode_forever;
   static const mode_type run_mode_time;
   static const mode_type run_mode_position;
@@ -254,10 +254,10 @@ public:
   static const mode_type stop_mode_coast;
   static const mode_type stop_mode_brake;
   static const mode_type stop_mode_hold;
-  
+
   static const mode_type position_mode_absolute;
   static const mode_type position_mode_relative;
-  
+
   using device::connected;
   using device::device_index;
 
@@ -340,7 +340,7 @@ public:
 
 
 //~autogen
-  
+
   void run(bool bRun=true) { set_attr_int("run",   bRun); }
   void stop()              { set_attr_int("run",   0);    }
   bool running() const { return get_attr_int("run")!=0; }
@@ -386,7 +386,7 @@ public:
 
   std::string command() const         { return get_attr_string("command"); }
   std::set<std::string> commands() const { return get_attr_set("commands"); }
-  
+
   //~autogen cpp_generic-get-set classes.dcMotor>currentClass
   void set_command(std::string v) { set_attr_string("command", v); }
 
@@ -431,7 +431,7 @@ public:
   using device::device_index;
 
   std::set<std::string> commands() const { return get_attr_set("commands"); }
-  
+
   //~autogen cpp_generic-get-set classes.servoMotor>currentClass
   std::string command() const { return get_attr_string("command"); }
   void set_command(std::string v) { set_attr_string("command", v); }
@@ -471,19 +471,19 @@ public:
   led(std::string name);
 
   using device::connected;
-  
+
   int brightness() const { return get_attr_int("brightness"); }
   void set_brightness(int v)    { set_attr_int("brightness", v); }
 
   inline int max_brightness() const { return _max_brightness; }
-  
+
   void on()  { set_attr_int("brightness", _max_brightness); }
   void off() { set_attr_int("brightness", 0); }
-  
+
   void flash(unsigned interval_ms);
   void set_on_delay (unsigned ms) { set_attr_int("delay_on",  ms); }
   void set_off_delay(unsigned ms) { set_attr_int("delay_off", ms); }
-  
+
   mode_type trigger()  const  { return get_attr_from_set("trigger"); }
   mode_set  triggers() const  { return get_attr_set     ("trigger"); }
   void set_trigger(const mode_type &v) { set_attr_string("trigger", v); }
@@ -499,7 +499,7 @@ public:
   static void green_off();
   static void all_on   ();
   static void all_off  ();
-  
+
 protected:
   int _max_brightness = 0;
 };
@@ -510,9 +510,9 @@ class power_supply : protected device
 {
 public:
   power_supply(std::string name);
-  
+
   using device::connected;
-  
+
   int   current_now()        const { return get_attr_int("current_now"); }
   float current_amps()       const { return get_attr_int("current_now") / 1000000.f; }
   int   current_max_design() const { return get_attr_int("current_max_design"); }
@@ -520,10 +520,10 @@ public:
   int   voltage_now()        const { return get_attr_int("voltage_now"); }
   float voltage_volts()      const { return get_attr_int("voltage_now") / 1000000.f; }
   int   voltage_max_design() const { return get_attr_int("voltage_max_design"); }
-  
+
   std::string technology() const { return get_attr_string("technology"); }
   std::string type()       const { return get_attr_string("type"); }
-  
+
   static power_supply battery;
 };
 
@@ -537,9 +537,9 @@ public:
   {
     delete _buf;
   }
-  
+
   bool pressed() const;
-  
+
   static button back;
   static button left;
   static button right;
@@ -563,10 +563,10 @@ class sound
 public:
   static void beep();
   static void tone(unsigned frequency, unsigned ms);
-  
+
   static void play (const std::string &soundfile, bool bSynchronous = false);
   static void speak(const std::string &text, bool bSynchronous = false);
-  
+
   static unsigned volume();
   static void set_volume(unsigned);
 };
@@ -587,15 +587,15 @@ public:
 
   uint32_t frame_buffer_size() const { return _fbsize; }
   uint32_t line_length()       const { return _llength; }
-  
+
   unsigned char *frame_buffer() { return _fb; }
-  
+
   void fill(unsigned char pixel);
-  
+
 protected:
   void init();
   void deinit();
-  
+
 private:
   unsigned char *_fb;
   uint32_t _fbsize;
@@ -613,7 +613,7 @@ public:
   remote_control(unsigned channel = 1);
   remote_control(infrared_sensor&, unsigned channel = 1);
   virtual ~remote_control();
-  
+
   inline bool   connected() const { return _sensor->connected(); }
   inline unsigned channel() const { return _channel+1; }
 
@@ -624,10 +624,10 @@ public:
   std::function<void (bool)> on_blue_up;
   std::function<void (bool)> on_blue_down;
   std::function<void (bool)> on_beacon;
-  
+
 protected:
   virtual void on_value_changed(int value);
-  
+
   enum
   {
     red_up    = (1 << 0),
@@ -636,7 +636,7 @@ protected:
     blue_down = (1 << 3),
     beacon    = (1 << 4),
   };
-  
+
 protected:
   infrared_sensor *_sensor = nullptr;
   bool             _owns_sensor = false;

--- a/cpp/ev3dev.h
+++ b/cpp/ev3dev.h
@@ -392,7 +392,7 @@ public:
   int duty_cycle() const { return get_attr_int("duty_cycle"); }
   void set_duty_cycle(int v) { set_attr_int("duty_cycle", v); }
     
-  std::string device_name() const { return get_attr_string("device_name"); }
+  std::string driver_name() const { return get_attr_string("driver_name"); }
 
   std::string port_name() const { return get_attr_string("port_name"); }
 
@@ -433,7 +433,7 @@ public:
   std::string command() const { return get_attr_string("command"); }
   void set_command(std::string v) { set_attr_string("command", v); }
     
-  std::string device_name() const { return get_attr_string("device_name"); }
+  std::string driver_name() const { return get_attr_string("driver_name"); }
 
   std::string port_name() const { return get_attr_string("port_name"); }
 

--- a/cpp/ev3dev.h
+++ b/cpp/ev3dev.h
@@ -260,75 +260,94 @@ public:
   using device::connected;
   using device::device_index;
 
-  inline const std::string port_name() const { return _port_name; }
+  //~autogen cpp_generic-get-set classes.motor>currentClass
+  int duty_cycle() const { return get_attr_int("duty_cycle"); }
 
-  motor_type type() const { return get_attr_string("type"); }
+  int duty_cycle_sp() const { return get_attr_int("duty_cycle_sp"); }
+  void set_duty_cycle_sp(int v) { set_attr_int("duty_cycle_sp", v); }
+    
+  std::string encoder_mode() const { return get_attr_string("encoder_mode"); }
+  void set_encoder_mode(std::string v) { set_attr_string("encoder_mode", v); }
+    
 
+  std::string emergency_stop() const { return get_attr_string("estop"); }
+  void set_emergency_stop(std::string v) { set_attr_string("estop", v); }
+    
+  std::string debug_log() const { return get_attr_string("log"); }
+
+  std::string polarity_mode() const { return get_attr_string("polarity_mode"); }
+  void set_polarity_mode(std::string v) { set_attr_string("polarity_mode", v); }
+    
+
+  std::string port_name() const { return get_attr_string("port_name"); }
+
+  int position() const { return get_attr_int("position"); }
+  void set_position(int v) { set_attr_int("position", v); }
+    
+  std::string position_mode() const { return get_attr_string("position_mode"); }
+  void set_position_mode(std::string v) { set_attr_string("position_mode", v); }
+    
+
+  int position_sp() const { return get_attr_int("position_sp"); }
+  void set_position_sp(int v) { set_attr_int("position_sp", v); }
+    
+  int pulses_per_second() const { return get_attr_int("pulses_per_second"); }
+
+  int pulses_per_second_sp() const { return get_attr_int("pulses_per_second_sp"); }
+  void set_pulses_per_second_sp(int v) { set_attr_int("pulses_per_second_sp", v); }
+    
+  int ramp_down_sp() const { return get_attr_int("ramp_down_sp"); }
+  void set_ramp_down_sp(int v) { set_attr_int("ramp_down_sp", v); }
+    
+  int ramp_up_sp() const { return get_attr_int("ramp_up_sp"); }
+  void set_ramp_up_sp(int v) { set_attr_int("ramp_up_sp", v); }
+    
+  std::string regulation_mode() const { return get_attr_string("regulation_mode"); }
+  void set_regulation_mode(std::string v) { set_attr_string("regulation_mode", v); }
+    
+
+  int run() const { return get_attr_int("run"); }
+  void set_run(int v) { set_attr_int("run", v); }
+    
+  std::string run_mode() const { return get_attr_string("run_mode"); }
+  void set_run_mode(std::string v) { set_attr_string("run_mode", v); }
+    
+
+  int speed_regulation_p() const { return get_attr_int("speed_regulation_P"); }
+  void set_speed_regulation_p(int v) { set_attr_int("speed_regulation_P", v); }
+    
+  int speed_regulation_i() const { return get_attr_int("speed_regulation_I"); }
+  void set_speed_regulation_i(int v) { set_attr_int("speed_regulation_I", v); }
+    
+  int speed_regulation_d() const { return get_attr_int("speed_regulation_D"); }
+  void set_speed_regulation_d(int v) { set_attr_int("speed_regulation_D", v); }
+    
+  int speed_regulation_k() const { return get_attr_int("speed_regulation_K"); }
+  void set_speed_regulation_k(int v) { set_attr_int("speed_regulation_K", v); }
+    
+  std::string state() const { return get_attr_string("state"); }
+
+  std::string stop_mode() const { return get_attr_string("stop_mode"); }
+  void set_stop_mode(std::string v) { set_attr_string("stop_mode", v); }
+    
+
+  int time_sp() const { return get_attr_int("time_sp"); }
+  void set_time_sp(int v) { set_attr_int("time_sp", v); }
+    
+  std::string type() const { return get_attr_string("type"); }
+
+
+//~autogen
+  
   void run(bool bRun=true) { set_attr_int("run",   bRun); }
   void stop()              { set_attr_int("run",   0);    }
+  bool running() const { return get_attr_int("run")!=0; }
   void reset()             { set_attr_int("reset", 1);    }
 
-  bool      running() const { return get_attr_int("run")!=0; }
-  mode_type state()   const { return get_attr_string("state"); }
-
-  int duty_cycle()        const { return get_attr_int("duty_cycle"); }
-  int pulses_per_second() const { return get_attr_int("pulses_per_second"); }
-  int position()          const { return get_attr_int("position"); }
-
-  void set_position(int p) { set_attr_int("position", p); }
-
-  // Stop Modes|String Array|Read
-
-  mode_type run_mode() const     { return get_attr_string("run_mode"); }
-  void set_run_mode(const mode_type &v) { set_attr_string("run_mode", v); }
-
-  mode_type stop_mode() const     { return get_attr_string("stop_mode"); }
-  void set_stop_mode(const mode_type &v) { set_attr_string("stop_mode", v); }
-
-  mode_type regulation_mode() const     { return get_attr_string("regulation_mode"); }
-  void set_regulation_mode(const mode_type &v) { set_attr_string("regulation_mode", v); }
-
-  mode_type position_mode() const     { return get_attr_string("position_mode"); }
-  void set_position_mode(const mode_type &v) { set_attr_string("position_mode", v); }
-
-  int  duty_cycle_setpoint() const { return get_attr_int("duty_cycle_sp"); }
-  void set_duty_cycle_setpoint(int v)     { set_attr_int("duty_cycle_sp", v); }
-
-  int  pulses_per_second_setpoint() const { return get_attr_int("pulses_per_second_sp"); }
-  void set_pulses_per_second_setpoint(int v)     { set_attr_int("pulses_per_second_sp", v); }
-
-  int  time_setpoint() const { return get_attr_int("time_sp"); }
-  void set_time_setpoint(int v)     { set_attr_int("time_sp", v); }
-
-  int  position_setpoint() const { return get_attr_int("position_sp"); }
-  void set_position_setpoint(int v)     { set_attr_int("position_sp", v); }
-
-  int  ramp_up() const { return get_attr_int("ramp_up_sp"); }
-  void set_ramp_up(int v)     { set_attr_int("ramp_up_sp", v); }
-
-  int  ramp_down() const { return get_attr_int("ramp_down_sp"); }
-  void set_ramp_down(int v)     { set_attr_int("ramp_down_sp", v); }
-
-  int speed_regulation_p() const { return get_attr_int("speed_regulation_p"); }
-  void set_speed_regulation_p(int v)    { set_attr_int("speed_regulation_p", v); }
-
-  int speed_regulation_i() const { return get_attr_int("speed_regulation_i"); }
-  void set_speed_regulation_i(int v)    { set_attr_int("speed_regulation_i", v); }
-
-  int speed_regulation_d() const { return get_attr_int("speed_regulation_d"); }
-  void set_speed_regulation_d(int v)    { set_attr_int("speed_regulation_d", v); }
-
-  int speed_regulation_k() const { return get_attr_int("speed_regulation_k"); }
-  void set_speed_regulation_k(int v) { set_attr_int("speed_regulation_k", v); }
-  
 protected:
   motor() {}
 
   bool connect(const std::map<std::string, std::set<std::string>>&) noexcept;
-  
-protected:
-  std::string _port_name;
-  motor_type  _type;
 };
 
 //-----------------------------------------------------------------------------
@@ -363,25 +382,31 @@ public:
   using device::connected;
   using device::device_index;
 
-  std::string port_name() const { return get_attr_string("port_name"); }
-  std::string type_name() const { return get_attr_string("name"); }
-
   std::string command() const         { return get_attr_string("command"); }
-  void set_command(const std::string &value) { set_attr_string("command", value); }
-  
   std::set<std::string> commands() const { return get_attr_set("commands"); }
-
-  int duty_cycle() const  { return get_attr_int("duty_cycle"); }
-  void set_duty_cycle(int value) { set_attr_int("duty_cycle", value); }
-
-  int ramp_down_ms() const  { return get_attr_int("ramp_down_ms"); }
-  void set_ramp_down_ms(int value) { set_attr_int("ramp_down_ms", value); }
   
-  int ramp_up_ms() const  { return get_attr_int("ramp_up_ms"); }
-  void set_ramp_up_ms(int value) { set_attr_int("ramp_up_ms", value); }
+  //~autogen cpp_generic-get-set classes.dcMotor>currentClass
+  void set_command(std::string v) { set_attr_string("command", v); }
+    
 
-  std::string polarity() const         { return get_attr_string("polarity"); }
-  void set_polarity(const std::string &value) { set_attr_string("polarity", value); }
+  int duty_cycle() const { return get_attr_int("duty_cycle"); }
+  void set_duty_cycle(int v) { set_attr_int("duty_cycle", v); }
+    
+  std::string device_name() const { return get_attr_string("device_name"); }
+
+  std::string port_name() const { return get_attr_string("port_name"); }
+
+  int ramp_down_ms() const { return get_attr_int("ramp_down_ms"); }
+  void set_ramp_down_ms(int v) { set_attr_int("ramp_down_ms", v); }
+    
+  int ramp_up_ms() const { return get_attr_int("ramp_up_ms"); }
+  void set_ramp_up_ms(int v) { set_attr_int("ramp_up_ms", v); }
+    
+  std::string polarity() const { return get_attr_string("polarity"); }
+  void set_polarity(std::string v) { set_attr_string("polarity", v); }
+    
+
+//~autogen
 
 protected:
   std::string _port_name;
@@ -402,29 +427,36 @@ public:
   using device::connected;
   using device::device_index;
 
-  std::string port_name() const { return get_attr_string("port_name"); }
-  std::string type_name() const { return get_attr_string("name"); }
-
-  std::string command() const         { return get_attr_string("command"); }
-  void set_command(const std::string &value) { set_attr_string("command", value); }
-
-  int position() const  { return get_attr_int("position"); }
-  void set_position(int value) { set_attr_int("position", value); }
-
-  int rate() const { return get_attr_int("rate"); }
-  void set_rate(int value) { set_attr_int("rate", value); }
-
-  int max_pulse_ms() const  { return get_attr_int("max_pulse_ms"); }
-  void set_max_pulse_ms(int value) { set_attr_int("max_pulse_ms", value); }
-
-  int mid_pulse_ms() const  { return get_attr_int("mid_pulse_ms"); }
-  void set_mid_pulse_ms(int value) { set_attr_int("mid_pulse_ms", value); }
-
-  int min_pulse_ms() const  { return get_attr_int("min_pulse_ms"); }
-  void set_min_pulse_ms(int value) { set_attr_int("min_pulse_ms", value); }
+  std::set<std::string> commands() const { return get_attr_set("commands"); }
   
-  std::string polarity() const         { return get_attr_string("polarity"); }
-  void set_polarity(const std::string &value) { set_attr_string("polarity", value); }
+  //~autogen cpp_generic-get-set classes.servoMotor>currentClass
+  std::string command() const { return get_attr_string("command"); }
+  void set_command(std::string v) { set_attr_string("command", v); }
+    
+  std::string device_name() const { return get_attr_string("device_name"); }
+
+  std::string port_name() const { return get_attr_string("port_name"); }
+
+  int max_pulse_ms() const { return get_attr_int("max_pulse_ms"); }
+  void set_max_pulse_ms(int v) { set_attr_int("max_pulse_ms", v); }
+    
+  int mid_pulse_ms() const { return get_attr_int("mid_pulse_ms"); }
+  void set_mid_pulse_ms(int v) { set_attr_int("mid_pulse_ms", v); }
+    
+  int min_pulse_ms() const { return get_attr_int("min_pulse_ms"); }
+  void set_min_pulse_ms(int v) { set_attr_int("min_pulse_ms", v); }
+    
+  std::string polarity() const { return get_attr_string("polarity"); }
+  void set_polarity(std::string v) { set_attr_string("polarity", v); }
+    
+  int position() const { return get_attr_int("position"); }
+  void set_position(int v) { set_attr_int("position", v); }
+    
+  int rate() const { return get_attr_int("rate"); }
+  void set_rate(int v) { set_attr_int("rate", v); }
+    
+
+//~autogen
 };
 
 //-----------------------------------------------------------------------------

--- a/cpp/ev3dev.h
+++ b/cpp/ev3dev.h
@@ -27,6 +27,9 @@
 #pragma once
 
 //-----------------------------------------------------------------------------
+//~autogen autogen-header
+//~autogen
+//-----------------------------------------------------------------------------
 
 #include <map>
 #include <set>
@@ -155,6 +158,8 @@ public:
   i2c_sensor(port_type port = INPUT_AUTO);
   i2c_sensor(port_type port, address_type address);
   
+  //~autogen cpp_generic-get-set classes.i2cSensor>currentClass
+  //~autogen
   std::string address()    const { return get_attr_string("address"); }
   int         fw_version() const { return get_attr_int("fw_version"); }
   int         poll_ms()    const { return get_attr_int("poll_ms"); }

--- a/cpp/ev3dev.h
+++ b/cpp/ev3dev.h
@@ -167,7 +167,8 @@ public:
 
   int poll_ms() const { return get_attr_int("poll_ms"); }
   void set_poll_ms(int v) { set_attr_int("poll_ms", v); }
-    
+
+
 
 //~autogen
 };
@@ -265,76 +266,77 @@ public:
 
   int duty_cycle_sp() const { return get_attr_int("duty_cycle_sp"); }
   void set_duty_cycle_sp(int v) { set_attr_int("duty_cycle_sp", v); }
-    
+
   std::string encoder_mode() const { return get_attr_string("encoder_mode"); }
   void set_encoder_mode(std::string v) { set_attr_string("encoder_mode", v); }
-    
+
 
   std::string emergency_stop() const { return get_attr_string("estop"); }
   void set_emergency_stop(std::string v) { set_attr_string("estop", v); }
-    
+
   std::string debug_log() const { return get_attr_string("log"); }
 
   std::string polarity_mode() const { return get_attr_string("polarity_mode"); }
   void set_polarity_mode(std::string v) { set_attr_string("polarity_mode", v); }
-    
+
 
   std::string port_name() const { return get_attr_string("port_name"); }
 
   int position() const { return get_attr_int("position"); }
   void set_position(int v) { set_attr_int("position", v); }
-    
+
   std::string position_mode() const { return get_attr_string("position_mode"); }
   void set_position_mode(std::string v) { set_attr_string("position_mode", v); }
-    
+
 
   int position_sp() const { return get_attr_int("position_sp"); }
   void set_position_sp(int v) { set_attr_int("position_sp", v); }
-    
+
   int pulses_per_second() const { return get_attr_int("pulses_per_second"); }
 
   int pulses_per_second_sp() const { return get_attr_int("pulses_per_second_sp"); }
   void set_pulses_per_second_sp(int v) { set_attr_int("pulses_per_second_sp", v); }
-    
+
   int ramp_down_sp() const { return get_attr_int("ramp_down_sp"); }
   void set_ramp_down_sp(int v) { set_attr_int("ramp_down_sp", v); }
-    
+
   int ramp_up_sp() const { return get_attr_int("ramp_up_sp"); }
   void set_ramp_up_sp(int v) { set_attr_int("ramp_up_sp", v); }
-    
+
   std::string regulation_mode() const { return get_attr_string("regulation_mode"); }
   void set_regulation_mode(std::string v) { set_attr_string("regulation_mode", v); }
-    
+
 
   int run() const { return get_attr_int("run"); }
   void set_run(int v) { set_attr_int("run", v); }
-    
+
   std::string run_mode() const { return get_attr_string("run_mode"); }
   void set_run_mode(std::string v) { set_attr_string("run_mode", v); }
-    
+
 
   int speed_regulation_p() const { return get_attr_int("speed_regulation_P"); }
   void set_speed_regulation_p(int v) { set_attr_int("speed_regulation_P", v); }
-    
+
   int speed_regulation_i() const { return get_attr_int("speed_regulation_I"); }
   void set_speed_regulation_i(int v) { set_attr_int("speed_regulation_I", v); }
-    
+
   int speed_regulation_d() const { return get_attr_int("speed_regulation_D"); }
   void set_speed_regulation_d(int v) { set_attr_int("speed_regulation_D", v); }
-    
+
   int speed_regulation_k() const { return get_attr_int("speed_regulation_K"); }
   void set_speed_regulation_k(int v) { set_attr_int("speed_regulation_K", v); }
-    
+
   std::string state() const { return get_attr_string("state"); }
 
   std::string stop_mode() const { return get_attr_string("stop_mode"); }
   void set_stop_mode(std::string v) { set_attr_string("stop_mode", v); }
-    
+
 
   int time_sp() const { return get_attr_int("time_sp"); }
   void set_time_sp(int v) { set_attr_int("time_sp", v); }
-    
+
   std::string type() const { return get_attr_string("type"); }
+
 
 
 //~autogen
@@ -387,24 +389,25 @@ public:
   
   //~autogen cpp_generic-get-set classes.dcMotor>currentClass
   void set_command(std::string v) { set_attr_string("command", v); }
-    
+
 
   int duty_cycle() const { return get_attr_int("duty_cycle"); }
   void set_duty_cycle(int v) { set_attr_int("duty_cycle", v); }
-    
+
   std::string driver_name() const { return get_attr_string("driver_name"); }
 
   std::string port_name() const { return get_attr_string("port_name"); }
 
   int ramp_down_ms() const { return get_attr_int("ramp_down_ms"); }
   void set_ramp_down_ms(int v) { set_attr_int("ramp_down_ms", v); }
-    
+
   int ramp_up_ms() const { return get_attr_int("ramp_up_ms"); }
   void set_ramp_up_ms(int v) { set_attr_int("ramp_up_ms", v); }
-    
+
   std::string polarity() const { return get_attr_string("polarity"); }
   void set_polarity(std::string v) { set_attr_string("polarity", v); }
-    
+
+
 
 //~autogen
 
@@ -432,29 +435,30 @@ public:
   //~autogen cpp_generic-get-set classes.servoMotor>currentClass
   std::string command() const { return get_attr_string("command"); }
   void set_command(std::string v) { set_attr_string("command", v); }
-    
+
   std::string driver_name() const { return get_attr_string("driver_name"); }
 
   std::string port_name() const { return get_attr_string("port_name"); }
 
   int max_pulse_ms() const { return get_attr_int("max_pulse_ms"); }
   void set_max_pulse_ms(int v) { set_attr_int("max_pulse_ms", v); }
-    
+
   int mid_pulse_ms() const { return get_attr_int("mid_pulse_ms"); }
   void set_mid_pulse_ms(int v) { set_attr_int("mid_pulse_ms", v); }
-    
+
   int min_pulse_ms() const { return get_attr_int("min_pulse_ms"); }
   void set_min_pulse_ms(int v) { set_attr_int("min_pulse_ms", v); }
-    
+
   std::string polarity() const { return get_attr_string("polarity"); }
   void set_polarity(std::string v) { set_attr_string("polarity", v); }
-    
+
   int position() const { return get_attr_int("position"); }
   void set_position(int v) { set_attr_int("position", v); }
-    
+
   int rate() const { return get_attr_int("rate"); }
   void set_rate(int v) { set_attr_int("rate", v); }
-    
+
+
 
 //~autogen
 };

--- a/cpp/ev3dev.h
+++ b/cpp/ev3dev.h
@@ -124,17 +124,17 @@ public:
   std::string type_name() const;
 
   //~autogen cpp_generic-get-set classes.sensor>currentClass
-  int decimals() const { return get_attr_int("decimals"); }
-  std::string mode() const { return get_attr_string("mode"); }
-  void set_mode(std::string v) { set_attr_string("mode", v); }
-  mode_set modes() const { return get_attr_set("modes"); }
-  void set_command(std::string v) { set_attr_string("command", v); }
-  mode_set commands() const { return get_attr_set("commands"); }
-  int num_values() const { return get_attr_int("num_values"); }
-  std::string port_name() const { return get_attr_string("port_name"); }
-  std::string units() const { return get_attr_string("units"); }
-  std::string driver_name() const { return get_attr_string("driver_name"); }
 
+    int decimals() const { return get_attr_int("decimals"); }
+    std::string mode() const { return get_attr_string("mode"); }
+    void set_mode(std::string v) { set_attr_string("mode", v); }
+    mode_set modes() const { return get_attr_set("modes"); }
+    void set_command(std::string v) { set_attr_string("command", v); }
+    mode_set commands() const { return get_attr_set("commands"); }
+    int num_values() const { return get_attr_int("num_values"); }
+    std::string port_name() const { return get_attr_string("port_name"); }
+    std::string units() const { return get_attr_string("units"); }
+    std::string driver_name() const { return get_attr_string("driver_name"); }
 
 //~autogen
 
@@ -153,11 +153,11 @@ public:
   i2c_sensor(port_type port, address_type address);
 
   //~autogen cpp_generic-get-set classes.i2cSensor>currentClass
-  std::string fw_version() const { return get_attr_string("fw_version"); }
-  std::string address() const { return get_attr_string("address"); }
-  int poll_ms() const { return get_attr_int("poll_ms"); }
-  void set_poll_ms(int v) { set_attr_int("poll_ms", v); }
 
+    std::string fw_version() const { return get_attr_string("fw_version"); }
+    std::string address() const { return get_attr_string("address"); }
+    int poll_ms() const { return get_attr_int("poll_ms"); }
+    void set_poll_ms(int v) { set_attr_int("poll_ms", v); }
 
 //~autogen
 };
@@ -251,57 +251,57 @@ public:
   using device::device_index;
 
   //~autogen cpp_generic-get-set classes.motor>currentClass
-  int duty_cycle() const { return get_attr_int("duty_cycle"); }
-  int duty_cycle_sp() const { return get_attr_int("duty_cycle_sp"); }
-  void set_duty_cycle_sp(int v) { set_attr_int("duty_cycle_sp", v); }
-  std::string encoder_mode() const { return get_attr_string("encoder_mode"); }
-  void set_encoder_mode(std::string v) { set_attr_string("encoder_mode", v); }
-  mode_set encoder_modes() const { return get_attr_set("encoder_modes"); }
-  std::string emergency_stop() const { return get_attr_string("estop"); }
-  void set_emergency_stop(std::string v) { set_attr_string("estop", v); }
-  std::string debug_log() const { return get_attr_string("log"); }
-  std::string polarity_mode() const { return get_attr_string("polarity_mode"); }
-  void set_polarity_mode(std::string v) { set_attr_string("polarity_mode", v); }
-  mode_set polarity_modes() const { return get_attr_set("polarity_modes"); }
-  std::string port_name() const { return get_attr_string("port_name"); }
-  int position() const { return get_attr_int("position"); }
-  void set_position(int v) { set_attr_int("position", v); }
-  std::string position_mode() const { return get_attr_string("position_mode"); }
-  void set_position_mode(std::string v) { set_attr_string("position_mode", v); }
-  mode_set position_modes() const { return get_attr_set("position_modes"); }
-  int position_sp() const { return get_attr_int("position_sp"); }
-  void set_position_sp(int v) { set_attr_int("position_sp", v); }
-  int pulses_per_second() const { return get_attr_int("pulses_per_second"); }
-  int pulses_per_second_sp() const { return get_attr_int("pulses_per_second_sp"); }
-  void set_pulses_per_second_sp(int v) { set_attr_int("pulses_per_second_sp", v); }
-  int ramp_down_sp() const { return get_attr_int("ramp_down_sp"); }
-  void set_ramp_down_sp(int v) { set_attr_int("ramp_down_sp", v); }
-  int ramp_up_sp() const { return get_attr_int("ramp_up_sp"); }
-  void set_ramp_up_sp(int v) { set_attr_int("ramp_up_sp", v); }
-  std::string regulation_mode() const { return get_attr_string("regulation_mode"); }
-  void set_regulation_mode(std::string v) { set_attr_string("regulation_mode", v); }
-  mode_set regulation_modes() const { return get_attr_set("regulation_modes"); }
-  int run() const { return get_attr_int("run"); }
-  void set_run(int v) { set_attr_int("run", v); }
-  std::string run_mode() const { return get_attr_string("run_mode"); }
-  void set_run_mode(std::string v) { set_attr_string("run_mode", v); }
-  mode_set run_modes() const { return get_attr_set("run_modes"); }
-  int speed_regulation_p() const { return get_attr_int("speed_regulation_P"); }
-  void set_speed_regulation_p(int v) { set_attr_int("speed_regulation_P", v); }
-  int speed_regulation_i() const { return get_attr_int("speed_regulation_I"); }
-  void set_speed_regulation_i(int v) { set_attr_int("speed_regulation_I", v); }
-  int speed_regulation_d() const { return get_attr_int("speed_regulation_D"); }
-  void set_speed_regulation_d(int v) { set_attr_int("speed_regulation_D", v); }
-  int speed_regulation_k() const { return get_attr_int("speed_regulation_K"); }
-  void set_speed_regulation_k(int v) { set_attr_int("speed_regulation_K", v); }
-  std::string state() const { return get_attr_string("state"); }
-  std::string stop_mode() const { return get_attr_string("stop_mode"); }
-  void set_stop_mode(std::string v) { set_attr_string("stop_mode", v); }
-  mode_set stop_modes() const { return get_attr_set("stop_modes"); }
-  int time_sp() const { return get_attr_int("time_sp"); }
-  void set_time_sp(int v) { set_attr_int("time_sp", v); }
-  std::string type() const { return get_attr_string("type"); }
 
+    int duty_cycle() const { return get_attr_int("duty_cycle"); }
+    int duty_cycle_sp() const { return get_attr_int("duty_cycle_sp"); }
+    void set_duty_cycle_sp(int v) { set_attr_int("duty_cycle_sp", v); }
+    std::string encoder_mode() const { return get_attr_string("encoder_mode"); }
+    void set_encoder_mode(std::string v) { set_attr_string("encoder_mode", v); }
+    mode_set encoder_modes() const { return get_attr_set("encoder_modes"); }
+    std::string emergency_stop() const { return get_attr_string("estop"); }
+    void set_emergency_stop(std::string v) { set_attr_string("estop", v); }
+    std::string debug_log() const { return get_attr_string("log"); }
+    std::string polarity_mode() const { return get_attr_string("polarity_mode"); }
+    void set_polarity_mode(std::string v) { set_attr_string("polarity_mode", v); }
+    mode_set polarity_modes() const { return get_attr_set("polarity_modes"); }
+    std::string port_name() const { return get_attr_string("port_name"); }
+    int position() const { return get_attr_int("position"); }
+    void set_position(int v) { set_attr_int("position", v); }
+    std::string position_mode() const { return get_attr_string("position_mode"); }
+    void set_position_mode(std::string v) { set_attr_string("position_mode", v); }
+    mode_set position_modes() const { return get_attr_set("position_modes"); }
+    int position_sp() const { return get_attr_int("position_sp"); }
+    void set_position_sp(int v) { set_attr_int("position_sp", v); }
+    int pulses_per_second() const { return get_attr_int("pulses_per_second"); }
+    int pulses_per_second_sp() const { return get_attr_int("pulses_per_second_sp"); }
+    void set_pulses_per_second_sp(int v) { set_attr_int("pulses_per_second_sp", v); }
+    int ramp_down_sp() const { return get_attr_int("ramp_down_sp"); }
+    void set_ramp_down_sp(int v) { set_attr_int("ramp_down_sp", v); }
+    int ramp_up_sp() const { return get_attr_int("ramp_up_sp"); }
+    void set_ramp_up_sp(int v) { set_attr_int("ramp_up_sp", v); }
+    std::string regulation_mode() const { return get_attr_string("regulation_mode"); }
+    void set_regulation_mode(std::string v) { set_attr_string("regulation_mode", v); }
+    mode_set regulation_modes() const { return get_attr_set("regulation_modes"); }
+    int run() const { return get_attr_int("run"); }
+    void set_run(int v) { set_attr_int("run", v); }
+    std::string run_mode() const { return get_attr_string("run_mode"); }
+    void set_run_mode(std::string v) { set_attr_string("run_mode", v); }
+    mode_set run_modes() const { return get_attr_set("run_modes"); }
+    int speed_regulation_p() const { return get_attr_int("speed_regulation_P"); }
+    void set_speed_regulation_p(int v) { set_attr_int("speed_regulation_P", v); }
+    int speed_regulation_i() const { return get_attr_int("speed_regulation_I"); }
+    void set_speed_regulation_i(int v) { set_attr_int("speed_regulation_I", v); }
+    int speed_regulation_d() const { return get_attr_int("speed_regulation_D"); }
+    void set_speed_regulation_d(int v) { set_attr_int("speed_regulation_D", v); }
+    int speed_regulation_k() const { return get_attr_int("speed_regulation_K"); }
+    void set_speed_regulation_k(int v) { set_attr_int("speed_regulation_K", v); }
+    std::string state() const { return get_attr_string("state"); }
+    std::string stop_mode() const { return get_attr_string("stop_mode"); }
+    void set_stop_mode(std::string v) { set_attr_string("stop_mode", v); }
+    mode_set stop_modes() const { return get_attr_set("stop_modes"); }
+    int time_sp() const { return get_attr_int("time_sp"); }
+    void set_time_sp(int v) { set_attr_int("time_sp", v); }
+    std::string type() const { return get_attr_string("type"); }
 
 //~autogen
 
@@ -349,19 +349,19 @@ public:
   using device::device_index;
 
   //~autogen cpp_generic-get-set classes.dcMotor>currentClass
-  void set_command(std::string v) { set_attr_string("command", v); }
-  mode_set commands() const { return get_attr_set("commands"); }
-  int duty_cycle() const { return get_attr_int("duty_cycle"); }
-  void set_duty_cycle(int v) { set_attr_int("duty_cycle", v); }
-  std::string driver_name() const { return get_attr_string("driver_name"); }
-  std::string port_name() const { return get_attr_string("port_name"); }
-  int ramp_down_ms() const { return get_attr_int("ramp_down_ms"); }
-  void set_ramp_down_ms(int v) { set_attr_int("ramp_down_ms", v); }
-  int ramp_up_ms() const { return get_attr_int("ramp_up_ms"); }
-  void set_ramp_up_ms(int v) { set_attr_int("ramp_up_ms", v); }
-  std::string polarity() const { return get_attr_string("polarity"); }
-  void set_polarity(std::string v) { set_attr_string("polarity", v); }
 
+    void set_command(std::string v) { set_attr_string("command", v); }
+    mode_set commands() const { return get_attr_set("commands"); }
+    int duty_cycle() const { return get_attr_int("duty_cycle"); }
+    void set_duty_cycle(int v) { set_attr_int("duty_cycle", v); }
+    std::string driver_name() const { return get_attr_string("driver_name"); }
+    std::string port_name() const { return get_attr_string("port_name"); }
+    int ramp_down_ms() const { return get_attr_int("ramp_down_ms"); }
+    void set_ramp_down_ms(int v) { set_attr_int("ramp_down_ms", v); }
+    int ramp_up_ms() const { return get_attr_int("ramp_up_ms"); }
+    void set_ramp_up_ms(int v) { set_attr_int("ramp_up_ms", v); }
+    std::string polarity() const { return get_attr_string("polarity"); }
+    void set_polarity(std::string v) { set_attr_string("polarity", v); }
 
 //~autogen
 
@@ -385,23 +385,23 @@ public:
   using device::device_index;
 
   //~autogen cpp_generic-get-set classes.servoMotor>currentClass
-  std::string command() const { return get_attr_string("command"); }
-  void set_command(std::string v) { set_attr_string("command", v); }
-  std::string driver_name() const { return get_attr_string("driver_name"); }
-  std::string port_name() const { return get_attr_string("port_name"); }
-  int max_pulse_ms() const { return get_attr_int("max_pulse_ms"); }
-  void set_max_pulse_ms(int v) { set_attr_int("max_pulse_ms", v); }
-  int mid_pulse_ms() const { return get_attr_int("mid_pulse_ms"); }
-  void set_mid_pulse_ms(int v) { set_attr_int("mid_pulse_ms", v); }
-  int min_pulse_ms() const { return get_attr_int("min_pulse_ms"); }
-  void set_min_pulse_ms(int v) { set_attr_int("min_pulse_ms", v); }
-  std::string polarity() const { return get_attr_string("polarity"); }
-  void set_polarity(std::string v) { set_attr_string("polarity", v); }
-  int position() const { return get_attr_int("position"); }
-  void set_position(int v) { set_attr_int("position", v); }
-  int rate() const { return get_attr_int("rate"); }
-  void set_rate(int v) { set_attr_int("rate", v); }
 
+    std::string command() const { return get_attr_string("command"); }
+    void set_command(std::string v) { set_attr_string("command", v); }
+    std::string driver_name() const { return get_attr_string("driver_name"); }
+    std::string port_name() const { return get_attr_string("port_name"); }
+    int max_pulse_ms() const { return get_attr_int("max_pulse_ms"); }
+    void set_max_pulse_ms(int v) { set_attr_int("max_pulse_ms", v); }
+    int mid_pulse_ms() const { return get_attr_int("mid_pulse_ms"); }
+    void set_mid_pulse_ms(int v) { set_attr_int("mid_pulse_ms", v); }
+    int min_pulse_ms() const { return get_attr_int("min_pulse_ms"); }
+    void set_min_pulse_ms(int v) { set_attr_int("min_pulse_ms", v); }
+    std::string polarity() const { return get_attr_string("polarity"); }
+    void set_polarity(std::string v) { set_attr_string("polarity", v); }
+    int position() const { return get_attr_int("position"); }
+    void set_position(int v) { set_attr_int("position", v); }
+    int rate() const { return get_attr_int("rate"); }
+    void set_rate(int v) { set_attr_int("rate", v); }
 
 //~autogen
 };
@@ -416,12 +416,12 @@ public:
   using device::connected;
 
   //~autogen cpp_generic-get-set classes.led>currentClass
-  int max_brightness() const { return get_attr_int("max_brightness"); }
-  int brightness() const { return get_attr_int("brightness"); }
-  void set_brightness(int v) { set_attr_int("brightness", v); }
-  std::string trigger() const { return get_attr_string("trigger"); }
-  void set_trigger(std::string v) { set_attr_string("trigger", v); }
 
+    int max_brightness() const { return get_attr_int("max_brightness"); }
+    int brightness() const { return get_attr_int("brightness"); }
+    void set_brightness(int v) { set_attr_int("brightness", v); }
+    std::string trigger() const { return get_attr_string("trigger"); }
+    void set_trigger(std::string v) { set_attr_string("trigger", v); }
 
 //~autogen
 
@@ -460,13 +460,13 @@ public:
   using device::connected;
 
   //~autogen cpp_generic-get-set classes.powerSupply>currentClass
-  int current_now() const { return get_attr_int("current_now"); }
-  int voltage_now() const { return get_attr_int("voltage_now"); }
-  int voltage_max_design() const { return get_attr_int("voltage_max_design"); }
-  int voltage_min_design() const { return get_attr_int("voltage_min_design"); }
-  std::string technology() const { return get_attr_string("technology"); }
-  std::string type() const { return get_attr_string("type"); }
 
+    int current_now() const { return get_attr_int("current_now"); }
+    int voltage_now() const { return get_attr_int("voltage_now"); }
+    int voltage_max_design() const { return get_attr_int("voltage_max_design"); }
+    int voltage_min_design() const { return get_attr_int("voltage_min_design"); }
+    std::string technology() const { return get_attr_string("technology"); }
+    std::string type() const { return get_attr_string("type"); }
 
 //~autogen
 

--- a/cpp/ev3dev.h
+++ b/cpp/ev3dev.h
@@ -384,7 +384,6 @@ public:
   using device::connected;
   using device::device_index;
 
-  std::string command() const         { return get_attr_string("command"); }
   std::set<std::string> commands() const { return get_attr_set("commands"); }
 
   //~autogen cpp_generic-get-set classes.dcMotor>currentClass

--- a/cpp/ev3dev.h
+++ b/cpp/ev3dev.h
@@ -341,10 +341,10 @@ public:
 
 //~autogen
 
-  void run(bool bRun=true) { set_attr_int("run",   bRun); }
-  void stop()              { set_attr_int("run",   0);    }
-  bool running() const { return get_attr_int("run")!=0; }
-  void reset()             { set_attr_int("reset", 1);    }
+  void start()         { set_attr_int("run", 1); }
+  void stop()          { set_attr_int("run", 0); }
+  bool running() const { return run(); }
+  void reset()         { set_attr_int("reset", 1);    }
 
 protected:
   motor() {}

--- a/cpp/ev3dev.h
+++ b/cpp/ev3dev.h
@@ -28,6 +28,7 @@
 
 //-----------------------------------------------------------------------------
 //~autogen autogen-header
+    // Sections of the following code were auto-generated based on spec v0.9.2-pre, rev 1. 
 //~autogen
 //-----------------------------------------------------------------------------
 
@@ -118,12 +119,13 @@ public:
   using device::connected;
   using device::device_index;
 
-  inline const std::string &port_name()   const { return _port_name; }
-  inline const sensor_type &type()        const { return _type; }
-         const std::string &type_name()   const;
-               std::string  units()       const { return get_attr_string("units"); }
-  inline unsigned           num_values()  const { return _nvalues; }
-  inline unsigned           dp()          const { return _dp; }
+  std::string port_name()   const { return get_attr_string("port_name"); }
+  std::string device_name() const { return get_attr_string("device_name"); }
+  std::string type_name()   const;
+  std::string units()       const { return get_attr_string("units"); }
+  
+  inline unsigned num_values()  const { return _nvalues; }
+  inline unsigned decimals()    const { return _dp; }
   
   int   value(unsigned index=0) const;
   float float_value(unsigned index=0) const;
@@ -132,20 +134,20 @@ public:
   const mode_type &mode()  const;
   
   void set_mode(const mode_type&);
+
+  void set_command(std::string v) { set_attr_string("command", v); }
   
 protected:
   sensor() {}
 
   bool connect(const std::map<std::string, std::set<std::string>>&) noexcept;
-  void init_members(bool);
+  void init_members();
   
 protected:
   unsigned _nvalues = 0;
   unsigned _dp = 0;
   float    _dp_scale = 1.f;
   
-  sensor_type _type;
-  port_type   _port_name;
   mode_set    _modes;
   mode_type   _mode;
 };
@@ -159,11 +161,15 @@ public:
   i2c_sensor(port_type port, address_type address);
   
   //~autogen cpp_generic-get-set classes.i2cSensor>currentClass
-  //~autogen
-  std::string address()    const { return get_attr_string("address"); }
-  int         fw_version() const { return get_attr_int("fw_version"); }
-  int         poll_ms()    const { return get_attr_int("poll_ms"); }
-  void    set_poll_ms(int v)            { set_attr_int("poll_ms", v); }
+  std::string fw_version() const { return get_attr_string("fw_version"); }
+
+  std::string address() const { return get_attr_string("address"); }
+
+  int poll_ms() const { return get_attr_int("poll_ms"); }
+  void set_poll_ms(int v) { set_attr_int("poll_ms", v); }
+    
+
+//~autogen
 };
 
 //-----------------------------------------------------------------------------

--- a/cpp/ev3dev.h
+++ b/cpp/ev3dev.h
@@ -119,37 +119,29 @@ public:
   using device::connected;
   using device::device_index;
 
-  std::string port_name()   const { return get_attr_string("port_name"); }
-  std::string device_name() const { return get_attr_string("device_name"); }
-  std::string type_name()   const;
-  std::string units()       const { return get_attr_string("units"); }
-
-  inline unsigned num_values()  const { return _nvalues; }
-  inline unsigned decimals()    const { return _dp; }
-
   int   value(unsigned index=0) const;
   float float_value(unsigned index=0) const;
+  std::string type_name() const;
 
-  const mode_set  &modes() const;
-  const mode_type &mode()  const;
-
-  void set_mode(const mode_type&);
-
+  //~autogen cpp_generic-get-set classes.sensor>currentClass
+  int decimals() const { return get_attr_int("decimals"); }
+  std::string mode() const { return get_attr_string("mode"); }
+  void set_mode(std::string v) { set_attr_string("mode", v); }
+  mode_set modes() const { return get_attr_set("modes"); }
   void set_command(std::string v) { set_attr_string("command", v); }
+  mode_set commands() const { return get_attr_set("commands"); }
+  int num_values() const { return get_attr_int("num_values"); }
+  std::string port_name() const { return get_attr_string("port_name"); }
+  std::string units() const { return get_attr_string("units"); }
+  std::string driver_name() const { return get_attr_string("driver_name"); }
+
+
+//~autogen
 
 protected:
   sensor() {}
 
   bool connect(const std::map<std::string, std::set<std::string>>&) noexcept;
-  void init_members();
-
-protected:
-  unsigned _nvalues = 0;
-  unsigned _dp = 0;
-  float    _dp_scale = 1.f;
-
-  mode_set    _modes;
-  mode_type   _mode;
 };
 
 //-----------------------------------------------------------------------------
@@ -162,12 +154,9 @@ public:
 
   //~autogen cpp_generic-get-set classes.i2cSensor>currentClass
   std::string fw_version() const { return get_attr_string("fw_version"); }
-
   std::string address() const { return get_attr_string("address"); }
-
   int poll_ms() const { return get_attr_int("poll_ms"); }
   void set_poll_ms(int v) { set_attr_int("poll_ms", v); }
-
 
 
 //~autogen
@@ -263,80 +252,55 @@ public:
 
   //~autogen cpp_generic-get-set classes.motor>currentClass
   int duty_cycle() const { return get_attr_int("duty_cycle"); }
-
   int duty_cycle_sp() const { return get_attr_int("duty_cycle_sp"); }
   void set_duty_cycle_sp(int v) { set_attr_int("duty_cycle_sp", v); }
-
   std::string encoder_mode() const { return get_attr_string("encoder_mode"); }
   void set_encoder_mode(std::string v) { set_attr_string("encoder_mode", v); }
-
-
+  mode_set encoder_modes() const { return get_attr_set("encoder_modes"); }
   std::string emergency_stop() const { return get_attr_string("estop"); }
   void set_emergency_stop(std::string v) { set_attr_string("estop", v); }
-
   std::string debug_log() const { return get_attr_string("log"); }
-
   std::string polarity_mode() const { return get_attr_string("polarity_mode"); }
   void set_polarity_mode(std::string v) { set_attr_string("polarity_mode", v); }
-
-
+  mode_set polarity_modes() const { return get_attr_set("polarity_modes"); }
   std::string port_name() const { return get_attr_string("port_name"); }
-
   int position() const { return get_attr_int("position"); }
   void set_position(int v) { set_attr_int("position", v); }
-
   std::string position_mode() const { return get_attr_string("position_mode"); }
   void set_position_mode(std::string v) { set_attr_string("position_mode", v); }
-
-
+  mode_set position_modes() const { return get_attr_set("position_modes"); }
   int position_sp() const { return get_attr_int("position_sp"); }
   void set_position_sp(int v) { set_attr_int("position_sp", v); }
-
   int pulses_per_second() const { return get_attr_int("pulses_per_second"); }
-
   int pulses_per_second_sp() const { return get_attr_int("pulses_per_second_sp"); }
   void set_pulses_per_second_sp(int v) { set_attr_int("pulses_per_second_sp", v); }
-
   int ramp_down_sp() const { return get_attr_int("ramp_down_sp"); }
   void set_ramp_down_sp(int v) { set_attr_int("ramp_down_sp", v); }
-
   int ramp_up_sp() const { return get_attr_int("ramp_up_sp"); }
   void set_ramp_up_sp(int v) { set_attr_int("ramp_up_sp", v); }
-
   std::string regulation_mode() const { return get_attr_string("regulation_mode"); }
   void set_regulation_mode(std::string v) { set_attr_string("regulation_mode", v); }
-
-
+  mode_set regulation_modes() const { return get_attr_set("regulation_modes"); }
   int run() const { return get_attr_int("run"); }
   void set_run(int v) { set_attr_int("run", v); }
-
   std::string run_mode() const { return get_attr_string("run_mode"); }
   void set_run_mode(std::string v) { set_attr_string("run_mode", v); }
-
-
+  mode_set run_modes() const { return get_attr_set("run_modes"); }
   int speed_regulation_p() const { return get_attr_int("speed_regulation_P"); }
   void set_speed_regulation_p(int v) { set_attr_int("speed_regulation_P", v); }
-
   int speed_regulation_i() const { return get_attr_int("speed_regulation_I"); }
   void set_speed_regulation_i(int v) { set_attr_int("speed_regulation_I", v); }
-
   int speed_regulation_d() const { return get_attr_int("speed_regulation_D"); }
   void set_speed_regulation_d(int v) { set_attr_int("speed_regulation_D", v); }
-
   int speed_regulation_k() const { return get_attr_int("speed_regulation_K"); }
   void set_speed_regulation_k(int v) { set_attr_int("speed_regulation_K", v); }
-
   std::string state() const { return get_attr_string("state"); }
-
   std::string stop_mode() const { return get_attr_string("stop_mode"); }
   void set_stop_mode(std::string v) { set_attr_string("stop_mode", v); }
-
-
+  mode_set stop_modes() const { return get_attr_set("stop_modes"); }
   int time_sp() const { return get_attr_int("time_sp"); }
   void set_time_sp(int v) { set_attr_int("time_sp", v); }
-
   std::string type() const { return get_attr_string("type"); }
-
 
 
 //~autogen
@@ -384,28 +348,19 @@ public:
   using device::connected;
   using device::device_index;
 
-  std::set<std::string> commands() const { return get_attr_set("commands"); }
-
   //~autogen cpp_generic-get-set classes.dcMotor>currentClass
   void set_command(std::string v) { set_attr_string("command", v); }
-
-
+  mode_set commands() const { return get_attr_set("commands"); }
   int duty_cycle() const { return get_attr_int("duty_cycle"); }
   void set_duty_cycle(int v) { set_attr_int("duty_cycle", v); }
-
   std::string driver_name() const { return get_attr_string("driver_name"); }
-
   std::string port_name() const { return get_attr_string("port_name"); }
-
   int ramp_down_ms() const { return get_attr_int("ramp_down_ms"); }
   void set_ramp_down_ms(int v) { set_attr_int("ramp_down_ms", v); }
-
   int ramp_up_ms() const { return get_attr_int("ramp_up_ms"); }
   void set_ramp_up_ms(int v) { set_attr_int("ramp_up_ms", v); }
-
   std::string polarity() const { return get_attr_string("polarity"); }
   void set_polarity(std::string v) { set_attr_string("polarity", v); }
-
 
 
 //~autogen
@@ -429,34 +384,23 @@ public:
   using device::connected;
   using device::device_index;
 
-  std::set<std::string> commands() const { return get_attr_set("commands"); }
-
   //~autogen cpp_generic-get-set classes.servoMotor>currentClass
   std::string command() const { return get_attr_string("command"); }
   void set_command(std::string v) { set_attr_string("command", v); }
-
   std::string driver_name() const { return get_attr_string("driver_name"); }
-
   std::string port_name() const { return get_attr_string("port_name"); }
-
   int max_pulse_ms() const { return get_attr_int("max_pulse_ms"); }
   void set_max_pulse_ms(int v) { set_attr_int("max_pulse_ms", v); }
-
   int mid_pulse_ms() const { return get_attr_int("mid_pulse_ms"); }
   void set_mid_pulse_ms(int v) { set_attr_int("mid_pulse_ms", v); }
-
   int min_pulse_ms() const { return get_attr_int("min_pulse_ms"); }
   void set_min_pulse_ms(int v) { set_attr_int("min_pulse_ms", v); }
-
   std::string polarity() const { return get_attr_string("polarity"); }
   void set_polarity(std::string v) { set_attr_string("polarity", v); }
-
   int position() const { return get_attr_int("position"); }
   void set_position(int v) { set_attr_int("position", v); }
-
   int rate() const { return get_attr_int("rate"); }
   void set_rate(int v) { set_attr_int("rate", v); }
-
 
 
 //~autogen
@@ -471,21 +415,24 @@ public:
 
   using device::connected;
 
+  //~autogen cpp_generic-get-set classes.led>currentClass
+  int max_brightness() const { return get_attr_int("max_brightness"); }
   int brightness() const { return get_attr_int("brightness"); }
-  void set_brightness(int v)    { set_attr_int("brightness", v); }
+  void set_brightness(int v) { set_attr_int("brightness", v); }
+  std::string trigger() const { return get_attr_string("trigger"); }
+  void set_trigger(std::string v) { set_attr_string("trigger", v); }
 
-  inline int max_brightness() const { return _max_brightness; }
 
-  void on()  { set_attr_int("brightness", _max_brightness); }
-  void off() { set_attr_int("brightness", 0); }
+//~autogen
+
+  mode_set  triggers() const  { return get_attr_set     ("trigger"); }
+
+  void on()  { set_brightness(max_brightness()); }
+  void off() { set_brightness(0); }
 
   void flash(unsigned interval_ms);
   void set_on_delay (unsigned ms) { set_attr_int("delay_on",  ms); }
   void set_off_delay(unsigned ms) { set_attr_int("delay_off", ms); }
-
-  mode_type trigger()  const  { return get_attr_from_set("trigger"); }
-  mode_set  triggers() const  { return get_attr_set     ("trigger"); }
-  void set_trigger(const mode_type &v) { set_attr_string("trigger", v); }
 
   static led red_right;
   static led red_left;
@@ -512,16 +459,19 @@ public:
 
   using device::connected;
 
-  int   current_now()        const { return get_attr_int("current_now"); }
-  float current_amps()       const { return get_attr_int("current_now") / 1000000.f; }
-  int   current_max_design() const { return get_attr_int("current_max_design"); }
-
-  int   voltage_now()        const { return get_attr_int("voltage_now"); }
-  float voltage_volts()      const { return get_attr_int("voltage_now") / 1000000.f; }
-  int   voltage_max_design() const { return get_attr_int("voltage_max_design"); }
-
+  //~autogen cpp_generic-get-set classes.powerSupply>currentClass
+  int current_now() const { return get_attr_int("current_now"); }
+  int voltage_now() const { return get_attr_int("voltage_now"); }
+  int voltage_max_design() const { return get_attr_int("voltage_max_design"); }
+  int voltage_min_design() const { return get_attr_int("voltage_min_design"); }
   std::string technology() const { return get_attr_string("technology"); }
-  std::string type()       const { return get_attr_string("type"); }
+  std::string type() const { return get_attr_string("type"); }
+
+
+//~autogen
+
+  float current_amps()       const { return current_now() / 1000000.f; }
+  float voltage_volts()      const { return voltage_now() / 1000000.f; }
 
   static power_supply battery;
 };

--- a/cpp/remote_control-test.cpp
+++ b/cpp/remote_control-test.cpp
@@ -46,15 +46,15 @@ int main()
   r.on_red_up    = bind(print_button, "red up",    placeholders::_1);
   r.on_blue_down = bind(print_button, "blue down", placeholders::_1);
   r.on_blue_up   = bind(print_button, "blue up",   placeholders::_1);
-  
+
   bool stop = false;
   r.on_beacon = [&] (bool state) { if (state) stop = true; };
-  
+
   cout << "ensure that channel 1 is selected," << endl
        << "press middle (beacon) button to exit!" << endl << endl;
-  
+
   while (!stop)
     r.process();
-  
+
   return 0;
 }


### PR DESCRIPTION
This finishes the work started by @fdetro on transferring the C++ bindings to the auto-generation system (see #44, #45). 

Some changes to the existing C++ API had to be made:
1. `motor::run(bool=true)` method was renamed to `motor::start()` to avoid ambiguity with the `run` property defined in specification. See commit message to ed83fff for more details.
2. `dc_motor::command()` method was removed, since [according to the latest specification](https://github.com/ev3dev/ev3dev-lang/blob/6b43d87f8355a825b76af2c0bb3c37efacbf2820/autogen/spec.json#L52) the `command` property is write-only.

The existing implementation caches property values and sets of properties in some cases ([an example](https://github.com/ev3dev/ev3dev-lang/blob/6b43d87f8355a825b76af2c0bb3c37efacbf2820/cpp/ev3dev.cpp#L550-L553)). The cached values may be [updated](https://github.com/ev3dev/ev3dev-lang/blob/6b43d87f8355a825b76af2c0bb3c37efacbf2820/cpp/ev3dev.cpp#L569) on e.g. a mode change. The autogeneration system does not allow this without moving some logic into the liquid template file. The code in this PR just re-reads a property each time it is accessed. I don;t think this should matter for the most user-cases, but I would be grateful if someone would actually checked this. For example, I know that performance was important for @dsharlet.

The tests and demos provided with the C++ bindings do work with this PR. Note that I only have motors and sensors from 31313 set, so I only checked those.