### PR TITLE
[cpp][autogen] Changing the C++ demos to work with the latest API

### DIFF
--- a/autogen/autogen-list.json
+++ b/autogen/autogen-list.json
@@ -1,6 +1,8 @@
 {
     "cpp": [
-        "cpp/ev3dev.h"
+        "cpp/ev3dev.h",
+        "cpp/ev3dev-lang-test.cpp",
+        "cpp/ev3dev-lang-demo.cpp"
     ],
     "python": [
         "python/ev3dev/pyev3dev.cpp"

--- a/autogen/templates/cpp_generic_report_status.liquid
+++ b/autogen/templates/cpp_generic_report_status.liquid
@@ -1,0 +1,7 @@
+{% for prop in currentClass.systemProperties %}{%
+  assign cppName = prop.name | downcase | underscore_spaces %}{%
+  if prop.readAccess == true %}
+         << "    {{ prop.name }}: " << dev.{{ cppName }}() << endl{%
+  endif %}{%
+endfor %}
+

--- a/cpp/Makefile
+++ b/cpp/Makefile
@@ -3,6 +3,7 @@ CFLAGS=-O2 -march=armv5
 CCFLAGS=-std=c++11 -D_GLIBCXX_USE_NANOSLEEP
 DEPS=ev3dev.h
 LIBS=-Llib -lev3dev -lstdc++ -lm
+RANLIB=ranlib
 
 obj/%.o: %.cpp $(DEPS)
 	mkdir -p $(@D)
@@ -11,7 +12,7 @@ obj/%.o: %.cpp $(DEPS)
 lib/libev3dev.a: obj/ev3dev.o
 	mkdir -p $(@D)
 	$(AR) rc $@ $^ && $(RANLIB) $@
-	
+
 bin/ev3dev-lang-test: lib/libev3dev.a obj/ev3dev-lang-test.o
 	mkdir -p $(@D)
 	$(CC) -o $@ $^ $(CFLAGS) $(CCFLAGS) $(LIBS)
@@ -27,7 +28,7 @@ bin/remote_control-test: lib/libev3dev.a obj/remote_control-test.o
 bin/drive-test: lib/libev3dev.a obj/drive-test.o
 	mkdir -p $(@D)
 	$(CC) -o $@ $^ $(CFLAGS) $(CCFLAGS) $(LIBS) -lpthread
-	
+
 bin/button-test: lib/libev3dev.a obj/button-test.o
 	mkdir -p $(@D)
 	$(CC) -o $@ $^ $(CFLAGS) $(CCFLAGS) $(LIBS)

--- a/cpp/ev3dev-lang-test.cpp
+++ b/cpp/ev3dev-lang-test.cpp
@@ -19,6 +19,12 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
+//-----------------------------------------------------------------------------
+//~autogen autogen-header
+    // Sections of the following code were auto-generated based on spec v0.9.2-pre, rev 3. 
+//~autogen
+//-----------------------------------------------------------------------------
+
 #include "ev3dev.h"
 
 #include <iostream>
@@ -28,16 +34,35 @@ using namespace std;
 using namespace ev3dev;
 
 
+std::ostream& operator<<(std::ostream &os, const std::set<std::string> &ss) {
+  os << "[ ";
+  for(const auto &s : ss) os << s << " ";
+  return os << "]";
+}
+
 template <class S>
 void test_sensor(const char *name)
 {
-  S s;
-  if (s.connected())
+  S dev;
+  if (dev.connected())
   {
     cout << endl
-         << "Found " << name << " sensor with mode " << s.mode()
-         << " on port " << s.port_name() << endl
-         << "  Current value is " << s.value() << endl << endl;
+         << "Found " << name << " sensor" << endl
+         << "  Current properties are:" << endl
+//~autogen cpp_generic_report_status classes.sensor>currentClass
+
+         << "    Commands: " << dev.commands() << endl
+         << "    Decimals: " << dev.decimals() << endl
+         << "    Driver Name: " << dev.driver_name() << endl
+         << "    Mode: " << dev.mode() << endl
+         << "    Modes: " << dev.modes() << endl
+         << "    Num Values: " << dev.num_values() << endl
+         << "    Port Name: " << dev.port_name() << endl
+         << "    Units: " << dev.units() << endl
+
+
+//~autogen
+         << endl;
   }
   else
     cout << "No " << name << " sensor found" << endl;
@@ -46,30 +71,46 @@ void test_sensor(const char *name)
 template <class M>
 void test_motor(const char *name)
 {
-  M m;
-  if (m.connected())
+  M dev;
+  if (dev.connected())
   {
     cout << endl
-         << "Found " << name << " motor on port " << m.port_name() << endl
+         << "Found " << name << " motor" << endl
+         << "  Current properties are:" << endl
+//~autogen cpp_generic_report_status classes.motor>currentClass
+
+         << "    Commands: " << dev.commands() << endl
+         << "    Count Per Rot: " << dev.count_per_rot() << endl
+         << "    Driver Name: " << dev.driver_name() << endl
+         << "    Duty Cycle: " << dev.duty_cycle() << endl
+         << "    Duty Cycle SP: " << dev.duty_cycle_sp() << endl
+         << "    Encoder Polarity: " << dev.encoder_polarity() << endl
+         << "    Polarity: " << dev.polarity() << endl
+         << "    Port Name: " << dev.port_name() << endl
+         << "    Position: " << dev.position() << endl
+         /* These are broken, see https://github.com/ev3dev/ev3dev/issues/314
+         << "    Position P: " << dev.position_p() << endl
+         << "    Position I: " << dev.position_i() << endl
+         << "    Position D: " << dev.position_d() << endl
+         */
+         << "    Position SP: " << dev.position_sp() << endl
+         << "    Speed: " << dev.speed() << endl
+         << "    Speed SP: " << dev.speed_sp() << endl
+         << "    Ramp Up SP: " << dev.ramp_up_sp() << endl
+         << "    Ramp Down SP: " << dev.ramp_down_sp() << endl
+         << "    Speed Regulation Enabled: " << dev.speed_regulation_enabled() << endl
+         << "    Speed Regulation P: " << dev.speed_regulation_p() << endl
+         << "    Speed Regulation I: " << dev.speed_regulation_i() << endl
+         << "    Speed Regulation D: " << dev.speed_regulation_d() << endl
+         << "    State: " << dev.state() << endl
+         << "    Stop Command: " << dev.stop_command() << endl
+         << "    Stop Commands: " << dev.stop_commands() << endl
+         << "    Time SP: " << dev.time_sp() << endl
+
+
+//~autogen
          << endl;
 
-    cout << "  Current state is " << m.state() << endl
-         << "    duty_cycle: " << m.duty_cycle() << endl
-         << "    pulses_per_second: " << m.pulses_per_second() << endl << endl
-         << "  Current run mode is " << m.run_mode() << endl
-         << "    stop mode: " << m.stop_mode() << endl
-         << "    regulation mode: " << m.regulation_mode() << endl << endl;
-
-    if (m.regulation_mode()==m.mode_on)
-      cout << "  pulses_per_second setpoint is " << m.pulses_per_second_sp() << endl;
-    else
-      cout << "  duty_cycle setpoint is " << m.duty_cycle_sp() << endl;
-
-    if (m.run_mode()==m.run_mode_time)
-      cout << "  Time setpoint is " << m.time_sp() << endl;
-    if (m.run_mode()==m.run_mode_position)
-      cout << "  Position setpoint is " << m.position_sp() << endl;
-    cout << "    ramp up: " << m.ramp_up_sp()  << "   ramp down: " << m.ramp_down_sp() << endl << endl;
   }
   else
     cout << "No " << name << " motor found" << endl;
@@ -77,18 +118,27 @@ void test_motor(const char *name)
 
 void test_dc_motor()
 {
-  dc_motor m;
-  if (m.connected())
+  dc_motor dev;
+  if (dev.connected())
   {
     cout << endl
-         << "Found dc motor on port " << m.port_name() << endl
-         << endl;
+         << "Found dc motor" << endl
+         << "  Current properties are:" << endl
+//~autogen cpp_generic_report_status classes.dcMotor>currentClass
 
-    cout << "  Current parameters" << endl
-         << "    duty_cycle:   " << m.duty_cycle() << endl
-         << "    ramp_up_ms:   " << m.ramp_up_ms() << endl << endl
-         << "    ramp_down_ms: " << m.ramp_down_ms() << endl << endl
-         << "    polarity:     " << m.polarity() << endl << endl;
+         << "    Command: " << dev.command() << endl
+         << "    Commands: " << dev.commands() << endl
+         << "    Driver Name: " << dev.driver_name() << endl
+         << "    Duty Cycle: " << dev.duty_cycle() << endl
+         << "    Duty Cycle SP: " << dev.duty_cycle_sp() << endl
+         << "    Polarity: " << dev.polarity() << endl
+         << "    Port Name: " << dev.port_name() << endl
+         << "    Ramp Down MS: " << dev.ramp_down_ms() << endl
+         << "    Ramp Up MS: " << dev.ramp_up_ms() << endl
+
+
+//~autogen
+         << endl;
   }
   else
     cout << "No dc motor found" << endl;
@@ -96,20 +146,27 @@ void test_dc_motor()
 
 void test_servo_motor()
 {
-  servo_motor m;
-  if (m.connected())
+  servo_motor dev;
+  if (dev.connected())
   {
     cout << endl
-         << "Found servo motor on port " << m.port_name() << endl
-         << endl;
+         << "Found servo motor" << endl
+         << "  Current properties are:" << endl
+//~autogen cpp_generic_report_status classes.servoMotor>currentClass
 
-    cout << "  Current command is " << m.command() << endl
-         << "    position:     " << m.position() << endl
-         << "    rate:         " << m.rate() << endl
-         << "    min_pulse_ms: " << m.min_pulse_ms() << endl << endl
-         << "    mid_pulse_ms: " << m.mid_pulse_ms() << endl << endl
-         << "    max_pulse_ms: " << m.max_pulse_ms() << endl << endl
-         << "    polarity:     " << m.polarity() << endl << endl;
+         << "    Command: " << dev.command() << endl
+         << "    Driver Name: " << dev.driver_name() << endl
+         << "    Max Pulse MS: " << dev.max_pulse_ms() << endl
+         << "    Mid Pulse MS: " << dev.mid_pulse_ms() << endl
+         << "    Min Pulse MS: " << dev.min_pulse_ms() << endl
+         << "    Polarity: " << dev.polarity() << endl
+         << "    Port Name: " << dev.port_name() << endl
+         << "    Position: " << dev.position() << endl
+         << "    Rate: " << dev.rate() << endl
+
+
+//~autogen
+         << endl;
   }
   else
     cout << "No servo motor found" << endl;
@@ -154,8 +211,8 @@ int main()
 
   cout << "Beeping..." << endl << endl; sound::beep();
 
-  cout << "Battery voltage is " << power_supply::battery.voltage_volts() << " V" << endl;
-  cout << "Battery current is " << power_supply::battery.current_amps() << " A" <<  endl;
+  cout << "Battery voltage is " << power_supply::battery.measured_volts() << " V" << endl;
+  cout << "Battery current is " << power_supply::battery.measured_amps() << " A" <<  endl;
 
   cout << endl;
 

--- a/cpp/ev3dev.h
+++ b/cpp/ev3dev.h
@@ -28,7 +28,7 @@
 
 //-----------------------------------------------------------------------------
 //~autogen autogen-header
-    // Sections of the following code were auto-generated based on spec v0.9.2-pre, rev 2. 
+    // Sections of the following code were auto-generated based on spec v0.9.2-pre, rev 3. 
 //~autogen
 //-----------------------------------------------------------------------------
 


### PR DESCRIPTION
The `ev3dev-lang-test.cpp` and `ev3dev-lang-demo.cpp` are now partially generated with the autogen system, so that they hopefully should be easier to adapt to future API changes. I had to manually comment out printing of `hold_pid/*` properties, see #53 and ev3dev/ev3dev#314.