### PR TITLE
[cpp][autogen] Show a message instead of throwing for unsupported property

### DIFF
--- a/autogen/templates/cpp_generic_report_status.liquid
+++ b/autogen/templates/cpp_generic_report_status.liquid
@@ -1,7 +1,9 @@
 {% for prop in currentClass.systemProperties %}{%
   assign cppName = prop.name | downcase | underscore_spaces %}{%
   if prop.readAccess == true %}
-         << "    {{ prop.name }}: " << dev.{{ cppName }}() << endl{%
+    cout << "    {{ prop.name }}: ";
+    try { cout << dev.{{ cppName }}() << endl; }
+    catch(...) { cout << "[not supported by the device]" << endl; }{%
   endif %}{%
 endfor %}
 

--- a/cpp/ev3dev-lang-demo.cpp
+++ b/cpp/ev3dev-lang-demo.cpp
@@ -199,40 +199,88 @@ void motor_action(motor &dev)
     switch (c)
     {
     case 'i':
-      cout << endl
+      cout << endl;
 //~autogen cpp_generic_report_status classes.motor>currentClass
 
-         << "    Commands: " << dev.commands() << endl
-         << "    Count Per Rot: " << dev.count_per_rot() << endl
-         << "    Driver Name: " << dev.driver_name() << endl
-         << "    Duty Cycle: " << dev.duty_cycle() << endl
-         << "    Duty Cycle SP: " << dev.duty_cycle_sp() << endl
-         << "    Encoder Polarity: " << dev.encoder_polarity() << endl
-         << "    Polarity: " << dev.polarity() << endl
-         << "    Port Name: " << dev.port_name() << endl
-         << "    Position: " << dev.position() << endl
-         /* These are broken, see https://github.com/ev3dev/ev3dev/issues/314
-         << "    Position P: " << dev.position_p() << endl
-         << "    Position I: " << dev.position_i() << endl
-         << "    Position D: " << dev.position_d() << endl
-         */
-         << "    Position SP: " << dev.position_sp() << endl
-         << "    Speed: " << dev.speed() << endl
-         << "    Speed SP: " << dev.speed_sp() << endl
-         << "    Ramp Up SP: " << dev.ramp_up_sp() << endl
-         << "    Ramp Down SP: " << dev.ramp_down_sp() << endl
-         << "    Speed Regulation Enabled: " << dev.speed_regulation_enabled() << endl
-         << "    Speed Regulation P: " << dev.speed_regulation_p() << endl
-         << "    Speed Regulation I: " << dev.speed_regulation_i() << endl
-         << "    Speed Regulation D: " << dev.speed_regulation_d() << endl
-         << "    State: " << dev.state() << endl
-         << "    Stop Command: " << dev.stop_command() << endl
-         << "    Stop Commands: " << dev.stop_commands() << endl
-         << "    Time SP: " << dev.time_sp() << endl
+    cout << "    Commands: ";
+    try { cout << dev.commands() << endl; }
+    catch(...) { cout << "[not supported by the device]" << endl; }
+    cout << "    Count Per Rot: ";
+    try { cout << dev.count_per_rot() << endl; }
+    catch(...) { cout << "[not supported by the device]" << endl; }
+    cout << "    Driver Name: ";
+    try { cout << dev.driver_name() << endl; }
+    catch(...) { cout << "[not supported by the device]" << endl; }
+    cout << "    Duty Cycle: ";
+    try { cout << dev.duty_cycle() << endl; }
+    catch(...) { cout << "[not supported by the device]" << endl; }
+    cout << "    Duty Cycle SP: ";
+    try { cout << dev.duty_cycle_sp() << endl; }
+    catch(...) { cout << "[not supported by the device]" << endl; }
+    cout << "    Encoder Polarity: ";
+    try { cout << dev.encoder_polarity() << endl; }
+    catch(...) { cout << "[not supported by the device]" << endl; }
+    cout << "    Polarity: ";
+    try { cout << dev.polarity() << endl; }
+    catch(...) { cout << "[not supported by the device]" << endl; }
+    cout << "    Port Name: ";
+    try { cout << dev.port_name() << endl; }
+    catch(...) { cout << "[not supported by the device]" << endl; }
+    cout << "    Position: ";
+    try { cout << dev.position() << endl; }
+    catch(...) { cout << "[not supported by the device]" << endl; }
+    cout << "    Position P: ";
+    try { cout << dev.position_p() << endl; }
+    catch(...) { cout << "[not supported by the device]" << endl; }
+    cout << "    Position I: ";
+    try { cout << dev.position_i() << endl; }
+    catch(...) { cout << "[not supported by the device]" << endl; }
+    cout << "    Position D: ";
+    try { cout << dev.position_d() << endl; }
+    catch(...) { cout << "[not supported by the device]" << endl; }
+    cout << "    Position SP: ";
+    try { cout << dev.position_sp() << endl; }
+    catch(...) { cout << "[not supported by the device]" << endl; }
+    cout << "    Speed: ";
+    try { cout << dev.speed() << endl; }
+    catch(...) { cout << "[not supported by the device]" << endl; }
+    cout << "    Speed SP: ";
+    try { cout << dev.speed_sp() << endl; }
+    catch(...) { cout << "[not supported by the device]" << endl; }
+    cout << "    Ramp Up SP: ";
+    try { cout << dev.ramp_up_sp() << endl; }
+    catch(...) { cout << "[not supported by the device]" << endl; }
+    cout << "    Ramp Down SP: ";
+    try { cout << dev.ramp_down_sp() << endl; }
+    catch(...) { cout << "[not supported by the device]" << endl; }
+    cout << "    Speed Regulation Enabled: ";
+    try { cout << dev.speed_regulation_enabled() << endl; }
+    catch(...) { cout << "[not supported by the device]" << endl; }
+    cout << "    Speed Regulation P: ";
+    try { cout << dev.speed_regulation_p() << endl; }
+    catch(...) { cout << "[not supported by the device]" << endl; }
+    cout << "    Speed Regulation I: ";
+    try { cout << dev.speed_regulation_i() << endl; }
+    catch(...) { cout << "[not supported by the device]" << endl; }
+    cout << "    Speed Regulation D: ";
+    try { cout << dev.speed_regulation_d() << endl; }
+    catch(...) { cout << "[not supported by the device]" << endl; }
+    cout << "    State: ";
+    try { cout << dev.state() << endl; }
+    catch(...) { cout << "[not supported by the device]" << endl; }
+    cout << "    Stop Command: ";
+    try { cout << dev.stop_command() << endl; }
+    catch(...) { cout << "[not supported by the device]" << endl; }
+    cout << "    Stop Commands: ";
+    try { cout << dev.stop_commands() << endl; }
+    catch(...) { cout << "[not supported by the device]" << endl; }
+    cout << "    Time SP: ";
+    try { cout << dev.time_sp() << endl; }
+    catch(...) { cout << "[not supported by the device]" << endl; }
 
 
 //~autogen
-           << endl;
+      cout << endl;
       break;
     case 'c':
       cout << "command " << dev.commands() << ": ";

--- a/cpp/ev3dev-lang-test.cpp
+++ b/cpp/ev3dev-lang-test.cpp
@@ -48,21 +48,37 @@ void test_sensor(const char *name)
   {
     cout << endl
          << "Found " << name << " sensor" << endl
-         << "  Current properties are:" << endl
+         << "  Current properties are:" << endl;
 //~autogen cpp_generic_report_status classes.sensor>currentClass
 
-         << "    Commands: " << dev.commands() << endl
-         << "    Decimals: " << dev.decimals() << endl
-         << "    Driver Name: " << dev.driver_name() << endl
-         << "    Mode: " << dev.mode() << endl
-         << "    Modes: " << dev.modes() << endl
-         << "    Num Values: " << dev.num_values() << endl
-         << "    Port Name: " << dev.port_name() << endl
-         << "    Units: " << dev.units() << endl
+    cout << "    Commands: ";
+    try { cout << dev.commands() << endl; }
+    catch(...) { cout << "[not supported by the device]" << endl; }
+    cout << "    Decimals: ";
+    try { cout << dev.decimals() << endl; }
+    catch(...) { cout << "[not supported by the device]" << endl; }
+    cout << "    Driver Name: ";
+    try { cout << dev.driver_name() << endl; }
+    catch(...) { cout << "[not supported by the device]" << endl; }
+    cout << "    Mode: ";
+    try { cout << dev.mode() << endl; }
+    catch(...) { cout << "[not supported by the device]" << endl; }
+    cout << "    Modes: ";
+    try { cout << dev.modes() << endl; }
+    catch(...) { cout << "[not supported by the device]" << endl; }
+    cout << "    Num Values: ";
+    try { cout << dev.num_values() << endl; }
+    catch(...) { cout << "[not supported by the device]" << endl; }
+    cout << "    Port Name: ";
+    try { cout << dev.port_name() << endl; }
+    catch(...) { cout << "[not supported by the device]" << endl; }
+    cout << "    Units: ";
+    try { cout << dev.units() << endl; }
+    catch(...) { cout << "[not supported by the device]" << endl; }
 
 
 //~autogen
-         << endl;
+    cout << endl;
   }
   else
     cout << "No " << name << " sensor found" << endl;
@@ -76,41 +92,88 @@ void test_motor(const char *name)
   {
     cout << endl
          << "Found " << name << " motor" << endl
-         << "  Current properties are:" << endl
+         << "  Current properties are:" << endl;
 //~autogen cpp_generic_report_status classes.motor>currentClass
 
-         << "    Commands: " << dev.commands() << endl
-         << "    Count Per Rot: " << dev.count_per_rot() << endl
-         << "    Driver Name: " << dev.driver_name() << endl
-         << "    Duty Cycle: " << dev.duty_cycle() << endl
-         << "    Duty Cycle SP: " << dev.duty_cycle_sp() << endl
-         << "    Encoder Polarity: " << dev.encoder_polarity() << endl
-         << "    Polarity: " << dev.polarity() << endl
-         << "    Port Name: " << dev.port_name() << endl
-         << "    Position: " << dev.position() << endl
-         /* These are broken, see https://github.com/ev3dev/ev3dev/issues/314
-         << "    Position P: " << dev.position_p() << endl
-         << "    Position I: " << dev.position_i() << endl
-         << "    Position D: " << dev.position_d() << endl
-         */
-         << "    Position SP: " << dev.position_sp() << endl
-         << "    Speed: " << dev.speed() << endl
-         << "    Speed SP: " << dev.speed_sp() << endl
-         << "    Ramp Up SP: " << dev.ramp_up_sp() << endl
-         << "    Ramp Down SP: " << dev.ramp_down_sp() << endl
-         << "    Speed Regulation Enabled: " << dev.speed_regulation_enabled() << endl
-         << "    Speed Regulation P: " << dev.speed_regulation_p() << endl
-         << "    Speed Regulation I: " << dev.speed_regulation_i() << endl
-         << "    Speed Regulation D: " << dev.speed_regulation_d() << endl
-         << "    State: " << dev.state() << endl
-         << "    Stop Command: " << dev.stop_command() << endl
-         << "    Stop Commands: " << dev.stop_commands() << endl
-         << "    Time SP: " << dev.time_sp() << endl
+    cout << "    Commands: ";
+    try { cout << dev.commands() << endl; }
+    catch(...) { cout << "[not supported by the device]" << endl; }
+    cout << "    Count Per Rot: ";
+    try { cout << dev.count_per_rot() << endl; }
+    catch(...) { cout << "[not supported by the device]" << endl; }
+    cout << "    Driver Name: ";
+    try { cout << dev.driver_name() << endl; }
+    catch(...) { cout << "[not supported by the device]" << endl; }
+    cout << "    Duty Cycle: ";
+    try { cout << dev.duty_cycle() << endl; }
+    catch(...) { cout << "[not supported by the device]" << endl; }
+    cout << "    Duty Cycle SP: ";
+    try { cout << dev.duty_cycle_sp() << endl; }
+    catch(...) { cout << "[not supported by the device]" << endl; }
+    cout << "    Encoder Polarity: ";
+    try { cout << dev.encoder_polarity() << endl; }
+    catch(...) { cout << "[not supported by the device]" << endl; }
+    cout << "    Polarity: ";
+    try { cout << dev.polarity() << endl; }
+    catch(...) { cout << "[not supported by the device]" << endl; }
+    cout << "    Port Name: ";
+    try { cout << dev.port_name() << endl; }
+    catch(...) { cout << "[not supported by the device]" << endl; }
+    cout << "    Position: ";
+    try { cout << dev.position() << endl; }
+    catch(...) { cout << "[not supported by the device]" << endl; }
+    cout << "    Position P: ";
+    try { cout << dev.position_p() << endl; }
+    catch(...) { cout << "[not supported by the device]" << endl; }
+    cout << "    Position I: ";
+    try { cout << dev.position_i() << endl; }
+    catch(...) { cout << "[not supported by the device]" << endl; }
+    cout << "    Position D: ";
+    try { cout << dev.position_d() << endl; }
+    catch(...) { cout << "[not supported by the device]" << endl; }
+    cout << "    Position SP: ";
+    try { cout << dev.position_sp() << endl; }
+    catch(...) { cout << "[not supported by the device]" << endl; }
+    cout << "    Speed: ";
+    try { cout << dev.speed() << endl; }
+    catch(...) { cout << "[not supported by the device]" << endl; }
+    cout << "    Speed SP: ";
+    try { cout << dev.speed_sp() << endl; }
+    catch(...) { cout << "[not supported by the device]" << endl; }
+    cout << "    Ramp Up SP: ";
+    try { cout << dev.ramp_up_sp() << endl; }
+    catch(...) { cout << "[not supported by the device]" << endl; }
+    cout << "    Ramp Down SP: ";
+    try { cout << dev.ramp_down_sp() << endl; }
+    catch(...) { cout << "[not supported by the device]" << endl; }
+    cout << "    Speed Regulation Enabled: ";
+    try { cout << dev.speed_regulation_enabled() << endl; }
+    catch(...) { cout << "[not supported by the device]" << endl; }
+    cout << "    Speed Regulation P: ";
+    try { cout << dev.speed_regulation_p() << endl; }
+    catch(...) { cout << "[not supported by the device]" << endl; }
+    cout << "    Speed Regulation I: ";
+    try { cout << dev.speed_regulation_i() << endl; }
+    catch(...) { cout << "[not supported by the device]" << endl; }
+    cout << "    Speed Regulation D: ";
+    try { cout << dev.speed_regulation_d() << endl; }
+    catch(...) { cout << "[not supported by the device]" << endl; }
+    cout << "    State: ";
+    try { cout << dev.state() << endl; }
+    catch(...) { cout << "[not supported by the device]" << endl; }
+    cout << "    Stop Command: ";
+    try { cout << dev.stop_command() << endl; }
+    catch(...) { cout << "[not supported by the device]" << endl; }
+    cout << "    Stop Commands: ";
+    try { cout << dev.stop_commands() << endl; }
+    catch(...) { cout << "[not supported by the device]" << endl; }
+    cout << "    Time SP: ";
+    try { cout << dev.time_sp() << endl; }
+    catch(...) { cout << "[not supported by the device]" << endl; }
 
 
 //~autogen
-         << endl;
-
+    cout << endl;
   }
   else
     cout << "No " << name << " motor found" << endl;
@@ -123,22 +186,40 @@ void test_dc_motor()
   {
     cout << endl
          << "Found dc motor" << endl
-         << "  Current properties are:" << endl
+         << "  Current properties are:" << endl;
 //~autogen cpp_generic_report_status classes.dcMotor>currentClass
 
-         << "    Command: " << dev.command() << endl
-         << "    Commands: " << dev.commands() << endl
-         << "    Driver Name: " << dev.driver_name() << endl
-         << "    Duty Cycle: " << dev.duty_cycle() << endl
-         << "    Duty Cycle SP: " << dev.duty_cycle_sp() << endl
-         << "    Polarity: " << dev.polarity() << endl
-         << "    Port Name: " << dev.port_name() << endl
-         << "    Ramp Down MS: " << dev.ramp_down_ms() << endl
-         << "    Ramp Up MS: " << dev.ramp_up_ms() << endl
+    cout << "    Command: ";
+    try { cout << dev.command() << endl; }
+    catch(...) { cout << "[not supported by the device]" << endl; }
+    cout << "    Commands: ";
+    try { cout << dev.commands() << endl; }
+    catch(...) { cout << "[not supported by the device]" << endl; }
+    cout << "    Driver Name: ";
+    try { cout << dev.driver_name() << endl; }
+    catch(...) { cout << "[not supported by the device]" << endl; }
+    cout << "    Duty Cycle: ";
+    try { cout << dev.duty_cycle() << endl; }
+    catch(...) { cout << "[not supported by the device]" << endl; }
+    cout << "    Duty Cycle SP: ";
+    try { cout << dev.duty_cycle_sp() << endl; }
+    catch(...) { cout << "[not supported by the device]" << endl; }
+    cout << "    Polarity: ";
+    try { cout << dev.polarity() << endl; }
+    catch(...) { cout << "[not supported by the device]" << endl; }
+    cout << "    Port Name: ";
+    try { cout << dev.port_name() << endl; }
+    catch(...) { cout << "[not supported by the device]" << endl; }
+    cout << "    Ramp Down MS: ";
+    try { cout << dev.ramp_down_ms() << endl; }
+    catch(...) { cout << "[not supported by the device]" << endl; }
+    cout << "    Ramp Up MS: ";
+    try { cout << dev.ramp_up_ms() << endl; }
+    catch(...) { cout << "[not supported by the device]" << endl; }
 
 
 //~autogen
-         << endl;
+    cout << endl;
   }
   else
     cout << "No dc motor found" << endl;
@@ -151,22 +232,40 @@ void test_servo_motor()
   {
     cout << endl
          << "Found servo motor" << endl
-         << "  Current properties are:" << endl
+         << "  Current properties are:" << endl;
 //~autogen cpp_generic_report_status classes.servoMotor>currentClass
 
-         << "    Command: " << dev.command() << endl
-         << "    Driver Name: " << dev.driver_name() << endl
-         << "    Max Pulse MS: " << dev.max_pulse_ms() << endl
-         << "    Mid Pulse MS: " << dev.mid_pulse_ms() << endl
-         << "    Min Pulse MS: " << dev.min_pulse_ms() << endl
-         << "    Polarity: " << dev.polarity() << endl
-         << "    Port Name: " << dev.port_name() << endl
-         << "    Position: " << dev.position() << endl
-         << "    Rate: " << dev.rate() << endl
+    cout << "    Command: ";
+    try { cout << dev.command() << endl; }
+    catch(...) { cout << "[not supported by the device]" << endl; }
+    cout << "    Driver Name: ";
+    try { cout << dev.driver_name() << endl; }
+    catch(...) { cout << "[not supported by the device]" << endl; }
+    cout << "    Max Pulse MS: ";
+    try { cout << dev.max_pulse_ms() << endl; }
+    catch(...) { cout << "[not supported by the device]" << endl; }
+    cout << "    Mid Pulse MS: ";
+    try { cout << dev.mid_pulse_ms() << endl; }
+    catch(...) { cout << "[not supported by the device]" << endl; }
+    cout << "    Min Pulse MS: ";
+    try { cout << dev.min_pulse_ms() << endl; }
+    catch(...) { cout << "[not supported by the device]" << endl; }
+    cout << "    Polarity: ";
+    try { cout << dev.polarity() << endl; }
+    catch(...) { cout << "[not supported by the device]" << endl; }
+    cout << "    Port Name: ";
+    try { cout << dev.port_name() << endl; }
+    catch(...) { cout << "[not supported by the device]" << endl; }
+    cout << "    Position: ";
+    try { cout << dev.position() << endl; }
+    catch(...) { cout << "[not supported by the device]" << endl; }
+    cout << "    Rate: ";
+    try { cout << dev.rate() << endl; }
+    catch(...) { cout << "[not supported by the device]" << endl; }
 
 
 //~autogen
-         << endl;
+    cout << endl;
   }
   else
     cout << "No servo motor found" << endl;


### PR DESCRIPTION
This changes the C++ demos to show a message instead of throwing if a property is unsupported by specific device. Example output of the `ev3dev-lang-test.cpp`:
```
Found large motor
  Current properties are:
    Commands: [ reset run-direct run-forever run-timed run-to-abs-pos run-to-rel-pos stop ]
    Count Per Rot: 360
    Driver Name: lego-ev3-l-motor
    Duty Cycle: 0
    Duty Cycle SP: 50
    Encoder Polarity: normal
    Polarity: normal
    Port Name: outB
    Position: 267
    Position P: [not supported by the device]
    Position I: [not supported by the device]
    Position D: [not supported by the device]
    Position SP: 100
    Speed: 0
    Speed SP: 0
    Ramp Up SP: 0
    Ramp Down SP: 0
    Speed Regulation Enabled: off
    Speed Regulation P: 1000
    Speed Regulation I: 60
    Speed Regulation D: 0
    State: [ ]
    Stop Command: coast
    Stop Commands: [ brake coast hold ]
    Time SP: 0
```
See #53 for details