### PR TITLE
[cpp] Add support for NXT ultrasonic sensor

### DIFF
--- a/cpp/ev3dev.cpp
+++ b/cpp/ev3dev.cpp
@@ -430,7 +430,7 @@ const sensor::sensor_type sensor::ev3_infrared    { "lego-ev3-uart-33" };
 const sensor::sensor_type sensor::nxt_touch       { "lego-nxt-touch" };
 const sensor::sensor_type sensor::nxt_light       { "lego-nxt-light" };
 const sensor::sensor_type sensor::nxt_sound       { "lego-nxt-sound" };
-const sensor::sensor_type sensor::nxt_ultrasonic  { "lego-nxt-ultrasonic" };
+const sensor::sensor_type sensor::nxt_ultrasonic  { "lego-nxt-us" };
 const sensor::sensor_type sensor::nxt_i2c_sensor  { "nxt-i2c-sensor" };
 
 //-----------------------------------------------------------------------------
@@ -563,7 +563,7 @@ const mode_type ultrasonic_sensor::mode_single_cm { "US-SI-CM"   };
 const mode_type ultrasonic_sensor::mode_single_in { "US-SI-IN"   };
 
 ultrasonic_sensor::ultrasonic_sensor(port_type port_) :
-  sensor(port_, { ev3_ultrasonic })
+  sensor(port_, { ev3_ultrasonic, nxt_ultrasonic })
 {
 }
 


### PR DESCRIPTION
This changes the driver name of the NXT ultrasonic sensor to
'lego-nxt-us' and alters the ev3dev::ultrasonic_sensor class constructor
to use either ev3 or nxt ultrasonic sensor.

See #45 for discussion, and thanks to @robojay for pointing at the problem and for helping with testing.