### PR TITLE
[cpp] Use either EV3 or NXT touch sensor with ev3dev::touch_sensor

### DIFF
--- a/cpp/ev3dev.cpp
+++ b/cpp/ev3dev.cpp
@@ -539,7 +539,7 @@ i2c_sensor::i2c_sensor(port_type port_, address_type address_)
 //-----------------------------------------------------------------------------
 
 touch_sensor::touch_sensor(port_type port_) :
-  sensor(port_, { ev3_touch })
+  sensor(port_, { ev3_touch, nxt_touch })
 {
 }
 


### PR DESCRIPTION
See #59 