### PR TITLE
[cpp] Expose remote control state

### DIFF
--- a/cpp/ev3dev.cpp
+++ b/cpp/ev3dev.cpp
@@ -1032,6 +1032,10 @@ void remote_control::on_value_changed(int value)
       static_cast<bool>(on_beacon))
     on_beacon(new_state & beacon);
 
+  if ((new_state != _state) &&
+          static_cast<bool>(on_state_change))
+      on_state_change(new_state);
+
   _state = new_state;
 }
 

--- a/cpp/ev3dev.h
+++ b/cpp/ev3dev.h
@@ -562,11 +562,9 @@ public:
   std::function<void (bool)> on_blue_up;
   std::function<void (bool)> on_blue_down;
   std::function<void (bool)> on_beacon;
+  std::function<void (int)>  on_state_change;
 
-protected:
-  virtual void on_value_changed(int value);
-
-  enum
+  enum buttons
   {
     red_up    = (1 << 0),
     red_down  = (1 << 1),
@@ -576,6 +574,8 @@ protected:
   };
 
 protected:
+  virtual void on_value_changed(int value);
+
   infrared_sensor *_sensor = nullptr;
   bool             _owns_sensor = false;
   unsigned         _channel = 0;


### PR DESCRIPTION
This allows users to provide a callable that gets called on
any change in remote control buttons state. This may be useful for processing
of multi-button events.

The enum in `remote_control` class that allows to use bitwise arithmetic
for checking individual buttons state is made public (and is given a name).

