### PR TITLE
[python][autogen] Treat write-only properties as properties in python

### DIFF
--- a/autogen/templates/python_generic-get-set.liquid
+++ b/autogen/templates/python_generic-get-set.liquid
@@ -2,7 +2,7 @@
 for prop in currentClass.systemProperties %}{%
   assign prop_name = prop.name | downcase | underscore_spaces %}{%
   if prop.readAccess == false %}
-            .def("set_{{ prop_name }}", &ev3::{{ class_name }}::set_{{ prop_name }}){%
+            .add_property("{{ prop_name }}", no_getter<ev3::{{ class_name }}>, &ev3::{{ class_name }}::set_{{ prop_name }}){%
   else %}
             .add_property("{{ prop_name }}", &ev3::{{ class_name }}::{{ prop_name }}{%
       if prop.writeAccess == true %}, &ev3::{{ class_name }}::set_{{ prop_name }}{% endif %}){%


### PR DESCRIPTION
```python
  d.command = 'run-forever'
```
is nicer than
```python
  d.set_command('run_forever')
```
Also, something like this is possible:
```python
  (d.speed_sp, d.time_sp, d.command) = (900, 5000, 'run-timed')
```