### PR TITLE
[autogen][cpp][python] Add lists of possible property values to specification

### DIFF
--- a/autogen/autogen-list.json
+++ b/autogen/autogen-list.json
@@ -1,6 +1,7 @@
 {
     "cpp": [
         "cpp/ev3dev.h",
+        "cpp/ev3dev.cpp",
         "cpp/ev3dev-lang-test.cpp",
         "cpp/ev3dev-lang-demo.cpp"
     ],

--- a/autogen/autogen.js
+++ b/autogen/autogen.js
@@ -105,6 +105,9 @@ liquidEngine.registerFilters({
     underscore_spaces: function (input) { //replaces sections of whitespace with underscores
         return String(input).replace(/\s/g, '_');
     },
+    underscore_non_wc: function (input) { //replaces non-word characters with underscores
+        return String(input).replace(/\W/g, '_');
+    },
     ternary_if: function (bool, valueIfTrue, valueIfFalse) { //ternary switch statement (also converts undefined values to blank string automatically)
         return bool ? (valueIfTrue == undefined ? '' : valueIfTrue ) : (valueIfFalse == undefined ? '' : valueIfFalse );
     },

--- a/autogen/spec.json
+++ b/autogen/spec.json
@@ -56,6 +56,7 @@
                 { "name": "Port Name", "systemName": "port_name", "type": "string", "readAccess": true, "writeAccess": false },
                 { "name": "Ramp Down SP", "systemName": "ramp_down_sp", "type": "int", "readAccess": true, "writeAccess": true },
                 { "name": "Ramp Up SP", "systemName": "ramp_up_sp", "type": "int", "readAccess": true, "writeAccess": true },
+                { "name": "State", "systemName": "state", "type": "string array", "readAccess": true, "writeAccess": false },
                 { "name": "Stop Command", "systemName": "stop_command", "type": "string", "readAccess": false, "writeAccess": true },
                 { "name": "Stop Commands", "systemName": "stop_commands", "type": "string array", "readAccess": true, "writeAccess": false }
             ]

--- a/autogen/spec.json
+++ b/autogen/spec.json
@@ -38,6 +38,49 @@
                 { "name": "Stop Command", "systemName": "stop_command", "type": "string", "readAccess": true, "writeAccess": true },
                 { "name": "Stop Commands", "systemName": "stop_commands", "type": "string array", "readAccess": true, "writeAccess": false },
                 { "name": "Time SP", "systemName": "time_sp", "type": "int", "readAccess": true, "writeAccess": true }
+            ],
+            "propertyValues": [
+                {
+                    "propertyName": "Command",
+                    "values": [
+                        { "name": "run-forever" },
+                        { "name": "run-to-abs-pos" },
+                        { "name": "run-to-rel-pos" },
+                        { "name": "run-timed" },
+                        { "name": "run-direct" },
+                        { "name": "stop" },
+                        { "name": "reset" }
+                    ]
+                },
+                {
+                    "propertyName": "Encoder Polarity",
+                    "values": [
+                        { "name": "normal" },
+                        { "name": "inverted" }
+                    ]
+                },
+                {
+                    "propertyName": "Polarity",
+                    "values": [
+                        { "name": "normal" },
+                        { "name": "inverted" }
+                    ]
+                },
+                {
+                    "propertyName": "Speed Regulation",
+                    "values": [
+                        { "name": "on" },
+                        { "name": "off" }
+                    ]
+                },
+                {
+                    "propertyName": "Stop Command",
+                    "values": [
+                        { "name": "coast" },
+                        { "name": "brake" },
+                        { "name": "hold" }
+                    ]
+                }
             ]
         },
         "dcMotor": {
@@ -59,6 +102,30 @@
                 { "name": "State", "systemName": "state", "type": "string array", "readAccess": true, "writeAccess": false },
                 { "name": "Stop Command", "systemName": "stop_command", "type": "string", "readAccess": false, "writeAccess": true },
                 { "name": "Stop Commands", "systemName": "stop_commands", "type": "string array", "readAccess": true, "writeAccess": false }
+            ],
+            "propertyValues": [
+                {
+                    "propertyName": "Command",
+                    "values": [
+                        { "name": "run-forever" },
+                        { "name": "run-timed" },
+                        { "name": "stop" }
+                    ]
+                },
+                {
+                    "propertyName": "Polarity",
+                    "values": [
+                        { "name": "normal" },
+                        { "name": "inverted" }
+                    ]
+                },
+                {
+                    "propertyName": "Stop Command",
+                    "values": [
+                        { "name": "coast" },
+                        { "name": "brake" }
+                    ]
+                }
             ]
         },
         "servoMotor": {
@@ -78,6 +145,22 @@
                 { "name": "Position SP", "systemName": "position_sp", "type": "int", "readAccess": true, "writeAccess": true },
                 { "name": "Rate SP", "systemName": "rate_sp", "type": "int", "readAccess": true, "writeAccess": true },
                 { "name": "State", "systemName": "state", "type": "string array", "readAccess": true, "writeAccess": false }
+            ],
+            "propertyValues": [
+                {
+                    "propertyName": "Command",
+                    "values": [
+                        { "name": "run" },
+                        { "name": "float" }
+                    ]
+                },
+                {
+                    "propertyName": "Polarity",
+                    "values": [
+                        { "name": "normal" },
+                        { "name": "inverted" }
+                    ]
+                }
             ]
         },
         "led": {
@@ -119,6 +202,94 @@
             "systemProperties": [
                 { "name": "FW Version", "systemName": "fw_version", "type": "string", "readAccess": true, "writeAccess": false },
                 { "name": "Poll MS", "systemName": "poll_ms", "type": "int", "readAccess": true, "writeAccess": true }
+            ]
+        },
+        "colorSensor": {
+            "friendlyName": "Color Sensor",
+            "description": "LEGO EV3 color sensor.",
+            "systemClassName":  "lego-sensor",
+            "systemDeviceNameConvention":  "sensor{0}",
+            "inheritance": [
+                "sensor"
+            ],
+            "propertyValues": [
+                {
+                    "propertyName": "Mode",
+                    "values": [
+                        { "name": "COL-REFLECT" },
+                        { "name": "COL-AMBIENT" },
+                        { "name": "COL-COLOR" },
+                        { "name": "REF-RAW" },
+                        { "name": "RGB-RAW" },
+                        { "name": "COL-CAL" }
+                    ]
+                }
+            ]
+        },
+        "ultrasonicSensor": {
+            "friendlyName": "Ultrasonic Sensor",
+            "description": "LEGO EV3 ultrasonic sensor.",
+            "systemClassName":  "lego-sensor",
+            "systemDeviceNameConvention":  "sensor{0}",
+            "inheritance": [
+                "sensor"
+            ],
+            "propertyValues": [
+                {
+                    "propertyName": "Mode",
+                    "values": [
+                        { "name": "US-DIST-CM" },
+                        { "name": "US-DIST-IN" },
+                        { "name": "US-LISTEN" },
+                        { "name": "US-SI-CM" },
+                        { "name": "US-SI-IN" },
+                        { "name": "US-DC-CM" },
+                        { "name": "US-DC-IN" }
+                    ]
+                }
+            ]
+        },
+        "gyroSensor": {
+            "friendlyName": "Gyro Sensor",
+            "description": "LEGO EV3 gyro sensor.",
+            "systemClassName":  "lego-sensor",
+            "systemDeviceNameConvention":  "sensor{0}",
+            "inheritance": [
+                "sensor"
+            ],
+            "propertyValues": [
+                {
+                    "propertyName": "Mode",
+                    "values": [
+                        { "name": "GYRO-ANG" },
+                        { "name": "GYRO-RATE" },
+                        { "name": "GYRO-FAS" },
+                        { "name": "GYRO-G&A" },
+                        { "name": "GYRO-CAL" }
+                    ]
+                }
+            ]
+        },
+        "infraredSensor": {
+            "friendlyName": "Infrared Sensor",
+            "description": "LEGO EV3 infrared sensor.",
+            "systemClassName":  "lego-sensor",
+            "systemDeviceNameConvention":  "sensor{0}",
+            "inheritance": [
+                "sensor"
+            ],
+            "propertyValues": [
+                {
+                    "propertyName": "Mode",
+                    "values": [
+                        { "name": "IR-PROX" },
+                        { "name": "IR-SEEK" },
+                        { "name": "IR-REMOTE" },
+                        { "name": "IR-REM-A" },
+                        { "name": "IR-S-ALT" },
+                        { "name": "IR-CAL" }
+                    ]
+                }
             ]
         },
         "powerSupply": {

--- a/autogen/templates/cpp_generic-declare-property-value.liquid
+++ b/autogen/templates/cpp_generic-declare-property-value.liquid
@@ -1,0 +1,7 @@
+{% for prop in currentClass.propertyValues %}{%
+  assign prefix = prop.propertyName | downcase | underscore_spaces %}{%
+  for value in prop.values %}{%
+    assign cppName = value.name | downcase | underscore_non_wc %}
+    static const std::string {{ prefix }}_{{cppName}};{%
+  endfor %}{%
+endfor %}

--- a/autogen/templates/cpp_generic-define-property-value.liquid
+++ b/autogen/templates/cpp_generic-define-property-value.liquid
@@ -1,0 +1,8 @@
+{% for prop in currentClass.propertyValues %}{%
+  assign className = currentClass.friendlyName | downcase | underscore_spaces %}{%
+  assign prefix = prop.propertyName | downcase | underscore_spaces %}{%
+  for value in prop.values %}{%
+    assign cppName = value.name | downcase | underscore_non_wc %}
+const std::string {{className}}::{{ prefix }}_{{cppName}}{ "{{ value.name }}" };{%
+  endfor %}{%
+endfor %}

--- a/autogen/templates/python_generic-property-value.liquid
+++ b/autogen/templates/python_generic-property-value.liquid
@@ -1,0 +1,8 @@
+{% for prop in currentClass.propertyValues %}{%
+  assign className = currentClass.friendlyName | downcase | underscore_spaces %}{%
+  assign prefix = prop.propertyName | downcase | underscore_spaces %}{%
+  for value in prop.values %}{%
+    assign cppName = value.name | downcase | underscore_non_wc %}
+        s.attr("{{prefix}}_{{ cppName }}") = ev3::{{ className }}::{{ prefix }}_{{ cppName }};{%
+  endfor %}{%
+endfor %}

--- a/cpp/drive-test.cpp
+++ b/cpp/drive-test.cpp
@@ -298,7 +298,7 @@ void control::drive_autonomously()
     return;
   }
 
-  _sensor_ir.set_mode(infrared_sensor::mode_proximity);
+  _sensor_ir.set_mode(infrared_sensor::mode_ir_prox);
 
   while (!_terminate)
   {

--- a/cpp/ev3dev-lang-demo.cpp
+++ b/cpp/ev3dev-lang-demo.cpp
@@ -181,7 +181,7 @@ void motor_action(motor &dev)
          << "st(o)p command      [" << dev.stop_command()             << "]" << endl
          << "speed r(e)gulation  [" << dev.speed_regulation_enabled() << "]" << endl;
 
-    if (dev.speed_regulation_enabled()==dev.mode_on)
+    if (dev.speed_regulation_enabled()==dev.speed_regulation_on)
       cout << "speed (s)etpoint (" << dev.speed_sp() << ")" << endl;
     else
       cout << "duty cycle (s)etpoint (" << dev.duty_cycle_sp() << ")" << endl;
@@ -297,7 +297,7 @@ void motor_action(motor &dev)
       cin >> answer; dev.set_speed_regulation_enabled(answer); cout << endl;
       break;
     case 's':
-      if (dev.speed_regulation_enabled()==dev.mode_on)
+      if (dev.speed_regulation_enabled()==dev.speed_regulation_on)
       {
         cout << "speed: "; cin >> new_value; dev.set_speed_sp(new_value); cout << endl;
       }
@@ -381,12 +381,12 @@ void motor_action(servo_motor &m)
     cout << endl
          << "*** servo motor (" << m.port_name() << ") actions ***" << endl
          << endl
-         << "(c)ommand      [" << m.command()      << "]" << endl
-         << "(p)osition     (" << m.position()     << ")" << endl
-         << "(r)ate         (" << m.rate()         << ")" << endl
-         << "mi(n) pulse ms (" << m.min_pulse_ms() << ")" << endl
-         << "mi(d) pulse ms (" << m.mid_pulse_ms() << ")" << endl
-         << "ma(x) pulse ms (" << m.max_pulse_ms() << ")" << endl
+         << "(c)ommand" << endl
+         << "(p)osition_sp  (" << m.position_sp()  << ")" << endl
+         << "(r)ate_sp      (" << m.rate_sp()      << ")" << endl
+         << "mi(n) pulse sp (" << m.min_pulse_sp() << ")" << endl
+         << "mi(d) pulse sp (" << m.mid_pulse_sp() << ")" << endl
+         << "ma(x) pulse sp (" << m.max_pulse_sp() << ")" << endl
          << "p(o)larity     [" << m.polarity()     << "]" << endl;
     cout << endl << "(b)ack" << endl
          << endl
@@ -400,23 +400,23 @@ void motor_action(servo_motor &m)
       cin >> new_mode; m.set_command(new_mode); cout << endl;
       break;
     case 'p':
-      cout << "position: "; cin >> new_value; m.set_position(new_value); cout << endl;
+      cout << "position sp: "; cin >> new_value; m.set_position_sp(new_value); cout << endl;
       break;
     case 'o':
       cout << "polarity (normal, inverted): ";
       cin >> new_mode; m.set_polarity(new_mode); cout << endl;
       break;
     case 'r':
-      cout << "rate: "; cin >> new_value; m.set_rate(new_value); cout << endl;
+      cout << "rate sp: "; cin >> new_value; m.set_rate_sp(new_value); cout << endl;
       break;
     case 'n':
-      cout << "min pulse ms: "; cin >> new_value; m.set_min_pulse_ms(new_value); cout << endl;
+      cout << "min pulse sp: "; cin >> new_value; m.set_min_pulse_sp(new_value); cout << endl;
       break;
     case 'd':
-      cout << "mid pulse ms: "; cin >> new_value; m.set_mid_pulse_ms(new_value); cout << endl;
+      cout << "mid pulse sp: "; cin >> new_value; m.set_mid_pulse_sp(new_value); cout << endl;
       break;
     case 'x':
-      cout << "max pulse ms: "; cin >> new_value; m.set_max_pulse_ms(new_value); cout << endl;
+      cout << "max pulse sp: "; cin >> new_value; m.set_max_pulse_sp(new_value); cout << endl;
       break;
     }
   }

--- a/cpp/ev3dev-lang-test.cpp
+++ b/cpp/ev3dev-lang-test.cpp
@@ -191,9 +191,6 @@ void test_dc_motor()
          << "  Current properties are:" << endl;
 //~autogen cpp_generic_report_status classes.dcMotor>currentClass
 
-    cout << "    Command: ";
-    try { cout << dev.command() << endl; }
-    catch(...) { cout << "[" << strerror(errno) << "]" << endl; }
     cout << "    Commands: ";
     try { cout << dev.commands() << endl; }
     catch(...) { cout << "[" << strerror(errno) << "]" << endl; }
@@ -217,6 +214,9 @@ void test_dc_motor()
     catch(...) { cout << "[" << strerror(errno) << "]" << endl; }
     cout << "    Ramp Up MS: ";
     try { cout << dev.ramp_up_ms() << endl; }
+    catch(...) { cout << "[" << strerror(errno) << "]" << endl; }
+    cout << "    Stop Commands: ";
+    try { cout << dev.stop_commands() << endl; }
     catch(...) { cout << "[" << strerror(errno) << "]" << endl; }
 
 

--- a/cpp/ev3dev-lang-test.cpp
+++ b/cpp/ev3dev-lang-test.cpp
@@ -209,11 +209,14 @@ void test_dc_motor()
     cout << "    Port Name: ";
     try { cout << dev.port_name() << endl; }
     catch(...) { cout << "[" << strerror(errno) << "]" << endl; }
-    cout << "    Ramp Down MS: ";
-    try { cout << dev.ramp_down_ms() << endl; }
+    cout << "    Ramp Down SP: ";
+    try { cout << dev.ramp_down_sp() << endl; }
     catch(...) { cout << "[" << strerror(errno) << "]" << endl; }
-    cout << "    Ramp Up MS: ";
-    try { cout << dev.ramp_up_ms() << endl; }
+    cout << "    Ramp Up SP: ";
+    try { cout << dev.ramp_up_sp() << endl; }
+    catch(...) { cout << "[" << strerror(errno) << "]" << endl; }
+    cout << "    State: ";
+    try { cout << dev.state() << endl; }
     catch(...) { cout << "[" << strerror(errno) << "]" << endl; }
     cout << "    Stop Commands: ";
     try { cout << dev.stop_commands() << endl; }

--- a/cpp/ev3dev.cpp
+++ b/cpp/ev3dev.cpp
@@ -23,6 +23,12 @@
  *
  */
 
+//-----------------------------------------------------------------------------
+//~autogen autogen-header
+    // Sections of the following code were auto-generated based on spec v0.9.2-pre, rev 3. 
+//~autogen
+//-----------------------------------------------------------------------------
+
 #include "ev3dev.h"
 
 #include <iostream>
@@ -545,9 +551,16 @@ touch_sensor::touch_sensor(port_type port_) :
 
 //-----------------------------------------------------------------------------
 
-const mode_type color_sensor::mode_reflect { "COL-REFLECT" };
-const mode_type color_sensor::mode_ambient { "COL-AMBIENT" };
-const mode_type color_sensor::mode_color   { "COL-COLOR"   };
+//~autogen cpp_generic-define-property-value classes.colorSensor>currentClass
+
+const std::string color_sensor::mode_col_reflect{ "COL-REFLECT" };
+const std::string color_sensor::mode_col_ambient{ "COL-AMBIENT" };
+const std::string color_sensor::mode_col_color{ "COL-COLOR" };
+const std::string color_sensor::mode_ref_raw{ "REF-RAW" };
+const std::string color_sensor::mode_rgb_raw{ "RGB-RAW" };
+const std::string color_sensor::mode_col_cal{ "COL-CAL" };
+
+//~autogen
 
 color_sensor::color_sensor(port_type port_) :
   sensor(port_, { ev3_color })
@@ -556,11 +569,17 @@ color_sensor::color_sensor(port_type port_) :
 
 //-----------------------------------------------------------------------------
 
-const mode_type ultrasonic_sensor::mode_dist_cm   { "US-DIST-CM" };
-const mode_type ultrasonic_sensor::mode_dist_in   { "US-DIST-IN" };
-const mode_type ultrasonic_sensor::mode_listen    { "US-LISTEN"  };
-const mode_type ultrasonic_sensor::mode_single_cm { "US-SI-CM"   };
-const mode_type ultrasonic_sensor::mode_single_in { "US-SI-IN"   };
+//~autogen cpp_generic-define-property-value classes.ultrasonicSensor>currentClass
+
+const std::string ultrasonic_sensor::mode_us_dist_cm{ "US-DIST-CM" };
+const std::string ultrasonic_sensor::mode_us_dist_in{ "US-DIST-IN" };
+const std::string ultrasonic_sensor::mode_us_listen{ "US-LISTEN" };
+const std::string ultrasonic_sensor::mode_us_si_cm{ "US-SI-CM" };
+const std::string ultrasonic_sensor::mode_us_si_in{ "US-SI-IN" };
+const std::string ultrasonic_sensor::mode_us_dc_cm{ "US-DC-CM" };
+const std::string ultrasonic_sensor::mode_us_dc_in{ "US-DC-IN" };
+
+//~autogen
 
 ultrasonic_sensor::ultrasonic_sensor(port_type port_) :
   sensor(port_, { ev3_ultrasonic, nxt_ultrasonic })
@@ -569,9 +588,15 @@ ultrasonic_sensor::ultrasonic_sensor(port_type port_) :
 
 //-----------------------------------------------------------------------------
 
-const mode_type gyro_sensor::mode_angle           { "GYRO-ANG"  };
-const mode_type gyro_sensor::mode_speed           { "GYRO-RATE" };
-const mode_type gyro_sensor::mode_angle_and_speed { "GYRO-G&A"  };
+//~autogen cpp_generic-define-property-value classes.gyroSensor>currentClass
+
+const std::string gyro_sensor::mode_gyro_ang{ "GYRO-ANG" };
+const std::string gyro_sensor::mode_gyro_rate{ "GYRO-RATE" };
+const std::string gyro_sensor::mode_gyro_fas{ "GYRO-FAS" };
+const std::string gyro_sensor::mode_gyro_g_a{ "GYRO-G&A" };
+const std::string gyro_sensor::mode_gyro_cal{ "GYRO-CAL" };
+
+//~autogen
 
 gyro_sensor::gyro_sensor(port_type port_) :
   sensor(port_, { ev3_gyro })
@@ -580,9 +605,16 @@ gyro_sensor::gyro_sensor(port_type port_) :
 
 //-----------------------------------------------------------------------------
 
-const mode_type infrared_sensor::mode_proximity { "IR-PROX"   };
-const mode_type infrared_sensor::mode_ir_seeker { "IR-SEEK"   };
-const mode_type infrared_sensor::mode_ir_remote { "IR-REMOTE" };
+//~autogen cpp_generic-define-property-value classes.infraredSensor>currentClass
+
+const std::string infrared_sensor::mode_ir_prox{ "IR-PROX" };
+const std::string infrared_sensor::mode_ir_seek{ "IR-SEEK" };
+const std::string infrared_sensor::mode_ir_remote{ "IR-REMOTE" };
+const std::string infrared_sensor::mode_ir_rem_a{ "IR-REM-A" };
+const std::string infrared_sensor::mode_ir_s_alt{ "IR-S-ALT" };
+const std::string infrared_sensor::mode_ir_cal{ "IR-CAL" };
+
+//~autogen
 
 infrared_sensor::infrared_sensor(port_type port_) :
   sensor(port_, { ev3_infrared })
@@ -594,19 +626,26 @@ infrared_sensor::infrared_sensor(port_type port_) :
 const motor::motor_type motor::motor_large  { "lego-ev3-l-motor" };
 const motor::motor_type motor::motor_medium { "lego-ev3-m-motor" };
 
-const mode_type motor::mode_off { "off" };
-const mode_type motor::mode_on  { "on"  };
+//~autogen cpp_generic-define-property-value classes.motor>currentClass
 
-const mode_type motor::run_mode_forever  { "forever"  };
-const mode_type motor::run_mode_time     { "time"     };
-const mode_type motor::run_mode_position { "position" };
+const std::string motor::command_run_forever{ "run-forever" };
+const std::string motor::command_run_to_abs_pos{ "run-to-abs-pos" };
+const std::string motor::command_run_to_rel_pos{ "run-to-rel-pos" };
+const std::string motor::command_run_timed{ "run-timed" };
+const std::string motor::command_run_direct{ "run-direct" };
+const std::string motor::command_stop{ "stop" };
+const std::string motor::command_reset{ "reset" };
+const std::string motor::encoder_polarity_normal{ "normal" };
+const std::string motor::encoder_polarity_inverted{ "inverted" };
+const std::string motor::polarity_normal{ "normal" };
+const std::string motor::polarity_inverted{ "inverted" };
+const std::string motor::speed_regulation_on{ "on" };
+const std::string motor::speed_regulation_off{ "off" };
+const std::string motor::stop_command_coast{ "coast" };
+const std::string motor::stop_command_brake{ "brake" };
+const std::string motor::stop_command_hold{ "hold" };
 
-const mode_type motor::stop_mode_coast { "coast" };
-const mode_type motor::stop_mode_brake { "brake" };
-const mode_type motor::stop_mode_hold  { "hold"  };
-
-const mode_type motor::position_mode_absolute { "absolute" };
-const mode_type motor::position_mode_relative { "relative" };
+//~autogen
 
 //-----------------------------------------------------------------------------
 
@@ -662,11 +701,17 @@ dc_motor::dc_motor(port_type port)
   connect(_strClassDir, _strPattern, {{ "port_name", { port }}});
 }
 
-const std::string dc_motor::command_run       { "run" };
-const std::string dc_motor::command_brake     { "brake" };
-const std::string dc_motor::command_coast     { "coast" };
-const std::string dc_motor::polarity_normal   { "normal" };
-const std::string dc_motor::polarity_inverted { "inverted" };
+//~autogen cpp_generic-define-property-value classes.dcMotor>currentClass
+
+const std::string dc_motor::command_run_forever{ "run-forever" };
+const std::string dc_motor::command_run_timed{ "run-timed" };
+const std::string dc_motor::command_stop{ "stop" };
+const std::string dc_motor::polarity_normal{ "normal" };
+const std::string dc_motor::polarity_inverted{ "inverted" };
+const std::string dc_motor::stop_command_coast{ "coast" };
+const std::string dc_motor::stop_command_brake{ "brake" };
+
+//~autogen
 
 //-----------------------------------------------------------------------------
 
@@ -678,10 +723,14 @@ servo_motor::servo_motor(port_type port)
   connect(_strClassDir, _strPattern, {{ "port_name", { port }}});
 }
 
-const std::string servo_motor::command_run       { "run" };
-const std::string servo_motor::command_float     { "float" };
-const std::string servo_motor::polarity_normal   { "normal" };
-const std::string servo_motor::polarity_inverted { "inverted" };
+//~autogen cpp_generic-define-property-value classes.servoMotor>currentClass
+
+const std::string servo_motor::command_run{ "run" };
+const std::string servo_motor::command_float{ "float" };
+const std::string servo_motor::polarity_normal{ "normal" };
+const std::string servo_motor::polarity_inverted{ "inverted" };
+
+//~autogen
 
 //-----------------------------------------------------------------------------
 

--- a/cpp/ev3dev.h
+++ b/cpp/ev3dev.h
@@ -176,9 +176,16 @@ class color_sensor : public sensor
 public:
   color_sensor(port_type port_ = INPUT_AUTO);
 
-  static const mode_type mode_reflect;
-  static const mode_type mode_ambient;
-  static const mode_type mode_color;
+  //~autogen cpp_generic-declare-property-value classes.colorSensor>currentClass
+
+    static const std::string mode_col_reflect;
+    static const std::string mode_col_ambient;
+    static const std::string mode_col_color;
+    static const std::string mode_ref_raw;
+    static const std::string mode_rgb_raw;
+    static const std::string mode_col_cal;
+
+//~autogen
 };
 
 //-----------------------------------------------------------------------------
@@ -188,11 +195,17 @@ class ultrasonic_sensor : public sensor
 public:
   ultrasonic_sensor(port_type port_ = INPUT_AUTO);
 
-  static const mode_type mode_dist_cm;
-  static const mode_type mode_dist_in;
-  static const mode_type mode_listen;
-  static const mode_type mode_single_cm;
-  static const mode_type mode_single_in;
+  //~autogen cpp_generic-declare-property-value classes.ultrasonicSensor>currentClass
+
+    static const std::string mode_us_dist_cm;
+    static const std::string mode_us_dist_in;
+    static const std::string mode_us_listen;
+    static const std::string mode_us_si_cm;
+    static const std::string mode_us_si_in;
+    static const std::string mode_us_dc_cm;
+    static const std::string mode_us_dc_in;
+
+//~autogen
 };
 
 //-----------------------------------------------------------------------------
@@ -202,9 +215,15 @@ class gyro_sensor : public sensor
 public:
   gyro_sensor(port_type port_ = INPUT_AUTO);
 
-  static const mode_type mode_angle;
-  static const mode_type mode_speed;
-  static const mode_type mode_angle_and_speed;
+  //~autogen cpp_generic-declare-property-value classes.gyroSensor>currentClass
+
+    static const std::string mode_gyro_ang;
+    static const std::string mode_gyro_rate;
+    static const std::string mode_gyro_fas;
+    static const std::string mode_gyro_g_a;
+    static const std::string mode_gyro_cal;
+
+//~autogen
 };
 
 //-----------------------------------------------------------------------------
@@ -214,9 +233,16 @@ class infrared_sensor : public sensor
 public:
   infrared_sensor(port_type port_ = INPUT_AUTO);
 
-  static const mode_type mode_proximity;
-  static const mode_type mode_ir_seeker;
-  static const mode_type mode_ir_remote;
+  //~autogen cpp_generic-declare-property-value classes.infraredSensor>currentClass
+
+    static const std::string mode_ir_prox;
+    static const std::string mode_ir_seek;
+    static const std::string mode_ir_remote;
+    static const std::string mode_ir_rem_a;
+    static const std::string mode_ir_s_alt;
+    static const std::string mode_ir_cal;
+
+//~autogen
 };
 
 //-----------------------------------------------------------------------------
@@ -232,22 +258,29 @@ public:
   static const motor_type motor_large;
   static const motor_type motor_medium;
 
-  static const mode_type mode_off;
-  static const mode_type mode_on;
-
-  static const mode_type run_mode_forever;
-  static const mode_type run_mode_time;
-  static const mode_type run_mode_position;
-
-  static const mode_type stop_mode_coast;
-  static const mode_type stop_mode_brake;
-  static const mode_type stop_mode_hold;
-
-  static const mode_type position_mode_absolute;
-  static const mode_type position_mode_relative;
-
   using device::connected;
   using device::device_index;
+
+  //~autogen cpp_generic-declare-property-value classes.motor>currentClass
+
+    static const std::string command_run_forever;
+    static const std::string command_run_to_abs_pos;
+    static const std::string command_run_to_rel_pos;
+    static const std::string command_run_timed;
+    static const std::string command_run_direct;
+    static const std::string command_stop;
+    static const std::string command_reset;
+    static const std::string encoder_polarity_normal;
+    static const std::string encoder_polarity_inverted;
+    static const std::string polarity_normal;
+    static const std::string polarity_inverted;
+    static const std::string speed_regulation_on;
+    static const std::string speed_regulation_off;
+    static const std::string stop_command_coast;
+    static const std::string stop_command_brake;
+    static const std::string stop_command_hold;
+
+//~autogen
 
   //~autogen cpp_generic-get-set classes.motor>currentClass
 
@@ -326,18 +359,23 @@ class dc_motor : protected device
 public:
   dc_motor(port_type port_ = OUTPUT_AUTO);
 
-  static const std::string command_run;
-  static const std::string command_brake;
-  static const std::string command_coast;
-  static const std::string polarity_normal;
-  static const std::string polarity_inverted;
-
   using device::connected;
   using device::device_index;
 
+  //~autogen cpp_generic-declare-property-value classes.dcMotor>currentClass
+
+    static const std::string command_run_forever;
+    static const std::string command_run_timed;
+    static const std::string command_stop;
+    static const std::string polarity_normal;
+    static const std::string polarity_inverted;
+    static const std::string stop_command_coast;
+    static const std::string stop_command_brake;
+
+//~autogen
+
   //~autogen cpp_generic-get-set classes.dcMotor>currentClass
 
-    std::string command() const { return get_attr_string("command"); }
     void set_command(std::string v) { set_attr_string("command", v); }
     mode_set commands() const { return get_attr_set("commands"); }
     std::string driver_name() const { return get_attr_string("driver_name"); }
@@ -351,6 +389,8 @@ public:
     void set_ramp_down_ms(int v) { set_attr_int("ramp_down_ms", v); }
     int ramp_up_ms() const { return get_attr_int("ramp_up_ms"); }
     void set_ramp_up_ms(int v) { set_attr_int("ramp_up_ms", v); }
+    void set_stop_command(std::string v) { set_attr_string("stop_command", v); }
+    mode_set stop_commands() const { return get_attr_set("stop_commands"); }
 
 //~autogen
 
@@ -365,13 +405,17 @@ class servo_motor : protected device
 public:
   servo_motor(port_type port_ = OUTPUT_AUTO);
 
-  static const std::string command_run;
-  static const std::string command_float;
-  static const std::string polarity_normal;
-  static const std::string polarity_inverted;
-
   using device::connected;
   using device::device_index;
+
+  //~autogen cpp_generic-declare-property-value classes.servoMotor>currentClass
+
+    static const std::string command_run;
+    static const std::string command_float;
+    static const std::string polarity_normal;
+    static const std::string polarity_inverted;
+
+//~autogen
 
   //~autogen cpp_generic-get-set classes.servoMotor>currentClass
 

--- a/cpp/ev3dev.h
+++ b/cpp/ev3dev.h
@@ -385,10 +385,11 @@ public:
     std::string polarity() const { return get_attr_string("polarity"); }
     void set_polarity(std::string v) { set_attr_string("polarity", v); }
     std::string port_name() const { return get_attr_string("port_name"); }
-    int ramp_down_ms() const { return get_attr_int("ramp_down_ms"); }
-    void set_ramp_down_ms(int v) { set_attr_int("ramp_down_ms", v); }
-    int ramp_up_ms() const { return get_attr_int("ramp_up_ms"); }
-    void set_ramp_up_ms(int v) { set_attr_int("ramp_up_ms", v); }
+    int ramp_down_sp() const { return get_attr_int("ramp_down_sp"); }
+    void set_ramp_down_sp(int v) { set_attr_int("ramp_down_sp", v); }
+    int ramp_up_sp() const { return get_attr_int("ramp_up_sp"); }
+    void set_ramp_up_sp(int v) { set_attr_int("ramp_up_sp", v); }
+    mode_set state() const { return get_attr_set("state"); }
     void set_stop_command(std::string v) { set_attr_string("stop_command", v); }
     mode_set stop_commands() const { return get_attr_set("stop_commands"); }
 


### PR DESCRIPTION
This provides possible values for writable string properties in `autogen/spec.json` and uses the information to generate corresponding string constants in C++ and python API.

Some design decisions:
    
* The value lists are located outside of the relevant property
  scopes. This is because there are several children of the sensor
  class, each with own mode sets.
* Each value is represented as object instead of as simple data. This
  is to allow extending the objects in the future. For example,
  value description could be added for documentation purposes.

See #67 for preceding discussion.