### PR TITLE
[autogen][python] Include spec and supported kernel versions into ev3dev.__version__

### DIFF
--- a/autogen/autogen-list.json
+++ b/autogen/autogen-list.json
@@ -6,7 +6,8 @@
         "cpp/ev3dev-lang-demo.cpp"
     ],
     "python": [
-        "python/ev3dev/pyev3dev.cpp"
+        "python/ev3dev/pyev3dev.cpp",
+        "python/spec_version.py"
     ],
     "js": [
         "js/extras.ts",

--- a/autogen/autogen.js
+++ b/autogen/autogen.js
@@ -16,7 +16,8 @@ var autogenFenceComments = {
     //XML-style regex here: http://regex101.com/r/cN6gE4
     '.md': { start: /<!--\s*~autogen *([\w-]+) *((\s*[\w\."']+>[\w\.]+)*)\s*-->/, end: "<!-- ~autogen -->" },
     //Lua regex: http://regex101.com/r/mI4gL1
-    '.lua': { start: /-- *~autogen *([\w-]+) *((\s*[\w\."']+>[\w\.]+)*)/, end: "-- ~autogen" }
+    '.lua': { start: /-- *~autogen *([\w-]+) *((\s*[\w\."']+>[\w\.]+)*)/, end: "-- ~autogen" },
+    '.py': { start: /#~autogen *([\w-]+) *((\s*[\w\."']+>[\w\.]+)*)/, end: "#~autogen" }
 }
 
 //Extension and helper methods

--- a/autogen/templates/python_spec_version.liquid
+++ b/autogen/templates/python_spec_version.liquid
@@ -1,0 +1,1 @@
+spec_version = "spec: {{ meta.version }}{% if meta.specRevision %}-r{{ meta.specRevision }}{% endif %}, kernel: {{ meta.supportedKernel }}"


### PR DESCRIPTION
This results in the following output in python:

```python
>>> import ev3dev
>>> ev3dev.__version__
0.1.1.post6 (spec: 0.9.2-pre-r3, kernel: v3.16.7-ckt10-4-ev3dev-ev3)
```