### PR TITLE
[autogen][py] Provide convenience functions for motor commands

### DIFF
--- a/autogen/autogen-list.json
+++ b/autogen/autogen-list.json
@@ -7,6 +7,7 @@
     ],
     "python": [
         "python/ev3dev/pyev3dev.cpp",
+        "python/ev3dev/__init__.py",
         "python/spec_version.py"
     ],
     "js": [

--- a/autogen/templates/python_motor_commands.liquid
+++ b/autogen/templates/python_motor_commands.liquid
@@ -1,0 +1,16 @@
+{% for prop in currentClass.propertyValues %}{%
+    if prop.propertyName == 'Command' %}{%
+        assign className = currentClass.friendlyName | downcase | underscore_spaces %}{%
+        for value in prop.values %}{%
+            assign commandName = value.name | downcase | underscore_non_wc %}
+def {{ className }}_{{ commandName }}(self, **attr):
+    for key in attr:
+        setattr(self, key, attr[key])
+    self.command = "{{ value.name }}"
+
+{{ className }}.{{commandName}} = {{ className }}_{{ commandName }}
+{%
+        endfor %}{%
+    endif %}{%
+endfor %}
+


### PR DESCRIPTION
This is in continuation of @dlech's [comment](https://github.com/ev3dev/ev3dev-lang/issues/51#issuecomment-98880821) in #51.

Each motor class (`tacho-motor`, `dc-motor`, `servo-motor`) provides a set of methods corresponding to possible commands. The methods take variable number of keyworded parameters. Each parameter should correspond to writable attribute of the motor. The attributes will be set before applying the command.

The methods are generated automatically based on the [list of possible commands](https://github.com/ev3dev/ev3dev-lang/blob/245b13fe8061e0ea7c0914ae9439f6c00aca7c35/autogen/spec.json#L46-L52) in `spec.json`.

Example:
```python
>>> m = large_motor()
>>> m.run_timed(time_sp=1000, duty_cycle_sp=75)
```
The second line is equivalent to
```python
>>> m.time_sp = 1000
>>> m.duty_cycle_sp = 75
>>> m.command = 'run-timed'
```