### PR TITLE
[autogen][cpp] Allow setters chaining and introduce motor commands

### DIFF
--- a/autogen/templates/cpp_generic-get-set.liquid
+++ b/autogen/templates/cpp_generic-get-set.liquid
@@ -12,7 +12,7 @@
     {{ type }} {{ cppName }}() const { return get_attr_{{ attr }}("{{ prop.systemName }}"); }{%
     endif %}{%
     if prop.writeAccess == true %}
-    void set_{{ cppName }}({{ type }} v) { set_attr_{{ attr }}("{{ prop.systemName }}", v); }{%
+    auto set_{{ cppName }}({{ type }} v) -> decltype(*this) { set_attr_{{ attr }}("{{ prop.systemName }}", v); return *this; }{%
     endif %}{%
   endif %}{%
 endfor %}

--- a/autogen/templates/cpp_motor_commands.liquid
+++ b/autogen/templates/cpp_motor_commands.liquid
@@ -1,0 +1,12 @@
+{% for prop in currentClass.propertyValues %}{%
+    if prop.propertyName == 'Command' %}{%
+        assign className = currentClass.friendlyName | downcase | underscore_spaces %}{%
+        for value in prop.values %}{%
+            assign commandName = value.name | downcase | underscore_non_wc %}{%
+            if commandName == 'float' %}{%
+                assign commandName = 'float_' %}{%
+            endif %}
+    void {{ commandName }}() { set_command("{{ value.name }}"); }{%
+        endfor %}{%
+    endif %}{%
+endfor %}

--- a/autogen/templates/python_generic-get-set.liquid
+++ b/autogen/templates/python_generic-get-set.liquid
@@ -2,9 +2,9 @@
 for prop in currentClass.systemProperties %}{%
   assign prop_name = prop.name | downcase | underscore_spaces %}{%
   if prop.readAccess == false %}
-            .add_property("{{ prop_name }}", no_getter<ev3::{{ class_name }}>, &ev3::{{ class_name }}::set_{{ prop_name }}){%
+            .add_property("{{ prop_name }}", no_getter<ev3::{{ class_name }}>, make_function(&ev3::{{ class_name }}::set_{{ prop_name }}, drop_return_value())){%
   else %}
             .add_property("{{ prop_name }}", &ev3::{{ class_name }}::{{ prop_name }}{%
-      if prop.writeAccess == true %}, &ev3::{{ class_name }}::set_{{ prop_name }}{% endif %}){%
+      if prop.writeAccess == true %}, make_function(&ev3::{{ class_name }}::set_{{ prop_name }}, drop_return_value()){% endif %}){%
   endif%}{%
 endfor %}

--- a/autogen/templates/python_motor_commands.liquid
+++ b/autogen/templates/python_motor_commands.liquid
@@ -13,4 +13,3 @@ def {{ className }}_{{ commandName }}(self, **attr):
         endfor %}{%
     endif %}{%
 endfor %}
-

--- a/cpp/drive-test.cpp
+++ b/cpp/drive-test.cpp
@@ -98,10 +98,8 @@ void control::drive(int speed, int time)
 
   if (time > 0)
   {
-    _motor_left .set_time_sp(time);
-    _motor_right.set_time_sp(time);
-    _motor_left.set_command("run-timed");
-    _motor_right.set_command("run-timed");
+    _motor_left .set_time_sp(time).run_timed();
+    _motor_right.set_time_sp(time).run_timed();
 
     while (_motor_left.state().count("running") || _motor_right.state().count("running"))
       this_thread::sleep_for(chrono::milliseconds(10));
@@ -110,8 +108,8 @@ void control::drive(int speed, int time)
   }
   else
   {
-    _motor_left.set_command("run-forever");
-    _motor_right.set_command("run-forever");
+    _motor_left.run_forever();
+    _motor_right.run_forever();
   }
 }
 
@@ -123,18 +121,10 @@ void control::turn(int direction)
   if (direction == 0)
     return;
 
-  _motor_left.set_position(0);
-  _motor_left.set_position_sp(direction);
-  _motor_left.set_duty_cycle_sp(50);
-
-  _motor_right.set_position(0);
-  _motor_right.set_position_sp(-direction);
-  _motor_right.set_duty_cycle_sp(50);
-
   _state = state_turning;
 
-  _motor_left .set_command("run-to-abs-pos");
-  _motor_right.set_command("run-to-abs-pos");
+  _motor_left. set_position_sp( direction).set_duty_cycle_sp(50).run_to_rel_pos();
+  _motor_right.set_position_sp(-direction).set_duty_cycle_sp(50).run_to_rel_pos();
 
   while (_motor_left.state().count("running") || _motor_right.state().count("running"))
     this_thread::sleep_for(chrono::milliseconds(10));
@@ -144,8 +134,8 @@ void control::turn(int direction)
 
 void control::stop()
 {
-  _motor_left .set_command("stop");
-  _motor_right.set_command("stop");
+  _motor_left .stop();
+  _motor_right.stop();
 
   _state = state_idle;
 }
@@ -153,10 +143,10 @@ void control::stop()
 void control::reset()
 {
   if (_motor_left.connected())
-    _motor_left .set_command("reset");
+    _motor_left.reset();
 
   if (_motor_right.connected())
-    _motor_right.set_command("reset");
+    _motor_right.reset();
 
   _state = state_idle;
 }

--- a/cpp/ev3dev.h
+++ b/cpp/ev3dev.h
@@ -125,12 +125,12 @@ public:
 
   //~autogen cpp_generic-get-set classes.sensor>currentClass
 
-    void set_command(std::string v) { set_attr_string("command", v); }
+    auto set_command(std::string v) -> decltype(*this) { set_attr_string("command", v); return *this; }
     mode_set commands() const { return get_attr_set("commands"); }
     int decimals() const { return get_attr_int("decimals"); }
     std::string driver_name() const { return get_attr_string("driver_name"); }
     std::string mode() const { return get_attr_string("mode"); }
-    void set_mode(std::string v) { set_attr_string("mode", v); }
+    auto set_mode(std::string v) -> decltype(*this) { set_attr_string("mode", v); return *this; }
     mode_set modes() const { return get_attr_set("modes"); }
     int num_values() const { return get_attr_int("num_values"); }
     std::string port_name() const { return get_attr_string("port_name"); }
@@ -156,7 +156,7 @@ public:
 
     std::string fw_version() const { return get_attr_string("fw_version"); }
     int poll_ms() const { return get_attr_int("poll_ms"); }
-    void set_poll_ms(int v) { set_attr_int("poll_ms", v); }
+    auto set_poll_ms(int v) -> decltype(*this) { set_attr_int("poll_ms", v); return *this; }
 
 //~autogen
 };
@@ -284,49 +284,61 @@ public:
 
   //~autogen cpp_generic-get-set classes.motor>currentClass
 
-    void set_command(std::string v) { set_attr_string("command", v); }
+    auto set_command(std::string v) -> decltype(*this) { set_attr_string("command", v); return *this; }
     mode_set commands() const { return get_attr_set("commands"); }
     int count_per_rot() const { return get_attr_int("count_per_rot"); }
     std::string driver_name() const { return get_attr_string("driver_name"); }
     int duty_cycle() const { return get_attr_int("duty_cycle"); }
     int duty_cycle_sp() const { return get_attr_int("duty_cycle_sp"); }
-    void set_duty_cycle_sp(int v) { set_attr_int("duty_cycle_sp", v); }
+    auto set_duty_cycle_sp(int v) -> decltype(*this) { set_attr_int("duty_cycle_sp", v); return *this; }
     std::string encoder_polarity() const { return get_attr_string("encoder_polarity"); }
-    void set_encoder_polarity(std::string v) { set_attr_string("encoder_polarity", v); }
+    auto set_encoder_polarity(std::string v) -> decltype(*this) { set_attr_string("encoder_polarity", v); return *this; }
     std::string polarity() const { return get_attr_string("polarity"); }
-    void set_polarity(std::string v) { set_attr_string("polarity", v); }
+    auto set_polarity(std::string v) -> decltype(*this) { set_attr_string("polarity", v); return *this; }
     std::string port_name() const { return get_attr_string("port_name"); }
     int position() const { return get_attr_int("position"); }
-    void set_position(int v) { set_attr_int("position", v); }
+    auto set_position(int v) -> decltype(*this) { set_attr_int("position", v); return *this; }
     int position_p() const { return get_attr_int("hold_pid/Kp"); }
-    void set_position_p(int v) { set_attr_int("hold_pid/Kp", v); }
+    auto set_position_p(int v) -> decltype(*this) { set_attr_int("hold_pid/Kp", v); return *this; }
     int position_i() const { return get_attr_int("hold_pid/Ki"); }
-    void set_position_i(int v) { set_attr_int("hold_pid/Ki", v); }
+    auto set_position_i(int v) -> decltype(*this) { set_attr_int("hold_pid/Ki", v); return *this; }
     int position_d() const { return get_attr_int("hold_pid/Kd"); }
-    void set_position_d(int v) { set_attr_int("hold_pid/Kd", v); }
+    auto set_position_d(int v) -> decltype(*this) { set_attr_int("hold_pid/Kd", v); return *this; }
     int position_sp() const { return get_attr_int("position_sp"); }
-    void set_position_sp(int v) { set_attr_int("position_sp", v); }
+    auto set_position_sp(int v) -> decltype(*this) { set_attr_int("position_sp", v); return *this; }
     int speed() const { return get_attr_int("speed"); }
     int speed_sp() const { return get_attr_int("speed_sp"); }
-    void set_speed_sp(int v) { set_attr_int("speed_sp", v); }
+    auto set_speed_sp(int v) -> decltype(*this) { set_attr_int("speed_sp", v); return *this; }
     int ramp_up_sp() const { return get_attr_int("ramp_up_sp"); }
-    void set_ramp_up_sp(int v) { set_attr_int("ramp_up_sp", v); }
+    auto set_ramp_up_sp(int v) -> decltype(*this) { set_attr_int("ramp_up_sp", v); return *this; }
     int ramp_down_sp() const { return get_attr_int("ramp_down_sp"); }
-    void set_ramp_down_sp(int v) { set_attr_int("ramp_down_sp", v); }
+    auto set_ramp_down_sp(int v) -> decltype(*this) { set_attr_int("ramp_down_sp", v); return *this; }
     std::string speed_regulation_enabled() const { return get_attr_string("speed_regulation"); }
-    void set_speed_regulation_enabled(std::string v) { set_attr_string("speed_regulation", v); }
+    auto set_speed_regulation_enabled(std::string v) -> decltype(*this) { set_attr_string("speed_regulation", v); return *this; }
     int speed_regulation_p() const { return get_attr_int("speed_pid/Kp"); }
-    void set_speed_regulation_p(int v) { set_attr_int("speed_pid/Kp", v); }
+    auto set_speed_regulation_p(int v) -> decltype(*this) { set_attr_int("speed_pid/Kp", v); return *this; }
     int speed_regulation_i() const { return get_attr_int("speed_pid/Ki"); }
-    void set_speed_regulation_i(int v) { set_attr_int("speed_pid/Ki", v); }
+    auto set_speed_regulation_i(int v) -> decltype(*this) { set_attr_int("speed_pid/Ki", v); return *this; }
     int speed_regulation_d() const { return get_attr_int("speed_pid/Kd"); }
-    void set_speed_regulation_d(int v) { set_attr_int("speed_pid/Kd", v); }
+    auto set_speed_regulation_d(int v) -> decltype(*this) { set_attr_int("speed_pid/Kd", v); return *this; }
     mode_set state() const { return get_attr_set("state"); }
     std::string stop_command() const { return get_attr_string("stop_command"); }
-    void set_stop_command(std::string v) { set_attr_string("stop_command", v); }
+    auto set_stop_command(std::string v) -> decltype(*this) { set_attr_string("stop_command", v); return *this; }
     mode_set stop_commands() const { return get_attr_set("stop_commands"); }
     int time_sp() const { return get_attr_int("time_sp"); }
-    void set_time_sp(int v) { set_attr_int("time_sp", v); }
+    auto set_time_sp(int v) -> decltype(*this) { set_attr_int("time_sp", v); return *this; }
+
+//~autogen
+
+    //~autogen cpp_motor_commands classes.motor>currentClass
+
+    void run_forever() { set_command("run-forever"); }
+    void run_to_abs_pos() { set_command("run-to-abs-pos"); }
+    void run_to_rel_pos() { set_command("run-to-rel-pos"); }
+    void run_timed() { set_command("run-timed"); }
+    void run_direct() { set_command("run-direct"); }
+    void stop() { set_command("stop"); }
+    void reset() { set_command("reset"); }
 
 //~autogen
 
@@ -376,22 +388,30 @@ public:
 
   //~autogen cpp_generic-get-set classes.dcMotor>currentClass
 
-    void set_command(std::string v) { set_attr_string("command", v); }
+    auto set_command(std::string v) -> decltype(*this) { set_attr_string("command", v); return *this; }
     mode_set commands() const { return get_attr_set("commands"); }
     std::string driver_name() const { return get_attr_string("driver_name"); }
     int duty_cycle() const { return get_attr_int("duty_cycle"); }
     int duty_cycle_sp() const { return get_attr_int("duty_cycle_sp"); }
-    void set_duty_cycle_sp(int v) { set_attr_int("duty_cycle_sp", v); }
+    auto set_duty_cycle_sp(int v) -> decltype(*this) { set_attr_int("duty_cycle_sp", v); return *this; }
     std::string polarity() const { return get_attr_string("polarity"); }
-    void set_polarity(std::string v) { set_attr_string("polarity", v); }
+    auto set_polarity(std::string v) -> decltype(*this) { set_attr_string("polarity", v); return *this; }
     std::string port_name() const { return get_attr_string("port_name"); }
     int ramp_down_sp() const { return get_attr_int("ramp_down_sp"); }
-    void set_ramp_down_sp(int v) { set_attr_int("ramp_down_sp", v); }
+    auto set_ramp_down_sp(int v) -> decltype(*this) { set_attr_int("ramp_down_sp", v); return *this; }
     int ramp_up_sp() const { return get_attr_int("ramp_up_sp"); }
-    void set_ramp_up_sp(int v) { set_attr_int("ramp_up_sp", v); }
+    auto set_ramp_up_sp(int v) -> decltype(*this) { set_attr_int("ramp_up_sp", v); return *this; }
     mode_set state() const { return get_attr_set("state"); }
-    void set_stop_command(std::string v) { set_attr_string("stop_command", v); }
+    auto set_stop_command(std::string v) -> decltype(*this) { set_attr_string("stop_command", v); return *this; }
     mode_set stop_commands() const { return get_attr_set("stop_commands"); }
+
+//~autogen
+
+    //~autogen cpp_motor_commands classes.dcMotor>currentClass
+
+    void run_forever() { set_command("run-forever"); }
+    void run_timed() { set_command("run-timed"); }
+    void stop() { set_command("stop"); }
 
 //~autogen
 
@@ -420,22 +440,29 @@ public:
 
   //~autogen cpp_generic-get-set classes.servoMotor>currentClass
 
-    void set_command(std::string v) { set_attr_string("command", v); }
+    auto set_command(std::string v) -> decltype(*this) { set_attr_string("command", v); return *this; }
     std::string driver_name() const { return get_attr_string("driver_name"); }
     int max_pulse_sp() const { return get_attr_int("max_pulse_sp"); }
-    void set_max_pulse_sp(int v) { set_attr_int("max_pulse_sp", v); }
+    auto set_max_pulse_sp(int v) -> decltype(*this) { set_attr_int("max_pulse_sp", v); return *this; }
     int mid_pulse_sp() const { return get_attr_int("mid_pulse_sp"); }
-    void set_mid_pulse_sp(int v) { set_attr_int("mid_pulse_sp", v); }
+    auto set_mid_pulse_sp(int v) -> decltype(*this) { set_attr_int("mid_pulse_sp", v); return *this; }
     int min_pulse_sp() const { return get_attr_int("min_pulse_sp"); }
-    void set_min_pulse_sp(int v) { set_attr_int("min_pulse_sp", v); }
+    auto set_min_pulse_sp(int v) -> decltype(*this) { set_attr_int("min_pulse_sp", v); return *this; }
     std::string polarity() const { return get_attr_string("polarity"); }
-    void set_polarity(std::string v) { set_attr_string("polarity", v); }
+    auto set_polarity(std::string v) -> decltype(*this) { set_attr_string("polarity", v); return *this; }
     std::string port_name() const { return get_attr_string("port_name"); }
     int position_sp() const { return get_attr_int("position_sp"); }
-    void set_position_sp(int v) { set_attr_int("position_sp", v); }
+    auto set_position_sp(int v) -> decltype(*this) { set_attr_int("position_sp", v); return *this; }
     int rate_sp() const { return get_attr_int("rate_sp"); }
-    void set_rate_sp(int v) { set_attr_int("rate_sp", v); }
+    auto set_rate_sp(int v) -> decltype(*this) { set_attr_int("rate_sp", v); return *this; }
     mode_set state() const { return get_attr_set("state"); }
+
+//~autogen
+
+    //~autogen cpp_motor_commands classes.servoMotor>currentClass
+
+    void run() { set_command("run"); }
+    void float_() { set_command("float"); }
 
 //~autogen
 };
@@ -453,9 +480,9 @@ public:
 
     int max_brightness() const { return get_attr_int("max_brightness"); }
     int brightness() const { return get_attr_int("brightness"); }
-    void set_brightness(int v) { set_attr_int("brightness", v); }
+    auto set_brightness(int v) -> decltype(*this) { set_attr_int("brightness", v); return *this; }
     std::string trigger() const { return get_attr_string("trigger"); }
-    void set_trigger(std::string v) { set_attr_string("trigger", v); }
+    auto set_trigger(std::string v) -> decltype(*this) { set_attr_string("trigger", v); return *this; }
 
 //~autogen
 


### PR DESCRIPTION
This is a two part change. The first part makes attribute setters return reference to the device. This makes possible chaining of setters:
```cpp
    d = large_motor();
    d.set_speed_regulation_enabled("on").set_speed_sp(600);
```
The second part introduces autogenerated methods corresponding to motor commands. This is similar to what was done in #75, but the methods take no arguments and just set the command attribute to the appropriate value. This may be combined with a chain of attribute setters:
```cpp
    d.set_time_sp(1000).set_duty_cycle_sp(75).run_timed();
```
See the [changes to drive-test.cpp](https://github.com/ev3dev/ev3dev-lang/pull/76/files#diff-0ebd249b66f8ec55f3988d72e9476a21) for some real examples of this.

I had to change the name of "float" command for servo_motor class to
"stop" since "float" is a keyword in C++.