### PR TITLE
Add class/property descriptions to specification

### DIFF
--- a/autogen/spec.json
+++ b/autogen/spec.json
@@ -7,37 +7,215 @@
     "classes": {
         "motor": {
             "friendlyName": "Motor",
-            "description": "The motor class provides a uniform interface for using motors with positional and directional feedback such as the EV3 and NXT motors. This feedback allows for precise control of the motors. This is the most common type of motor, so we just call it \"motor\".",
+            "description": [
+                "The motor class provides a uniform interface for using motors with",
+                "positional and directional feedback such as the EV3 and NXT motors.",
+                "This feedback allows for precise control of the motors. This is the",
+                "most common type of motor, so we just call it `motor`."
+                ],
             "docsLink": "http://www.ev3dev.org/docs/drivers/tacho-motor-class/",
             "systemClassName":  "tacho-motor",
             "systemDeviceNameConvention":  "motor{0}",
             "systemProperties": [
-                { "name": "Command", "systemName": "command", "type": "string", "readAccess": false, "writeAccess": true },
-                { "name": "Commands", "systemName": "commands", "type": "string array", "readAccess": true, "writeAccess": false },
-                { "name": "Count Per Rot", "systemName": "count_per_rot", "type": "int", "readAccess": true, "writeAccess": false },
-                { "name": "Driver Name", "systemName": "driver_name", "type": "string", "readAccess": true, "writeAccess": false },
-                { "name": "Duty Cycle", "systemName": "duty_cycle", "type": "int", "readAccess": true, "writeAccess": false },
-                { "name": "Duty Cycle SP", "systemName": "duty_cycle_sp", "type": "int", "readAccess": true, "writeAccess": true },
-                { "name": "Encoder Polarity", "systemName": "encoder_polarity", "type": "string", "readAccess": true, "writeAccess": true },
-                { "name": "Polarity", "systemName": "polarity", "type": "string", "readAccess": true, "writeAccess": true },
-                { "name": "Port Name", "systemName": "port_name", "type": "string", "readAccess": true, "writeAccess": false },
-                { "name": "Position", "systemName": "position", "type": "int", "readAccess": true, "writeAccess": true },
-                { "name": "Position P", "systemName": "hold_pid/Kp", "type": "int", "readAccess": true, "writeAccess": true },
-                { "name": "Position I", "systemName": "hold_pid/Ki", "type": "int", "readAccess": true, "writeAccess": true },
-                { "name": "Position D", "systemName": "hold_pid/Kd", "type": "int", "readAccess": true, "writeAccess": true },
-                { "name": "Position SP", "systemName": "position_sp", "type": "int", "readAccess": true, "writeAccess": true },
-                { "name": "Speed", "systemName": "speed", "type": "int", "readAccess": true, "writeAccess": false },
-                { "name": "Speed SP", "systemName": "speed_sp", "type": "int", "readAccess": true, "writeAccess": true },
-                { "name": "Ramp Up SP", "systemName": "ramp_up_sp", "type": "int", "readAccess": true, "writeAccess": true },
-                { "name": "Ramp Down SP", "systemName": "ramp_down_sp", "type": "int", "readAccess": true, "writeAccess": true },
-                { "name": "Speed Regulation Enabled", "systemName": "speed_regulation", "type": "string", "readAccess": true, "writeAccess": true },
-                { "name": "Speed Regulation P", "systemName": "speed_pid/Kp", "type": "int", "readAccess": true, "writeAccess": true },
-                { "name": "Speed Regulation I", "systemName": "speed_pid/Ki", "type": "int", "readAccess": true, "writeAccess": true },
-                { "name": "Speed Regulation D", "systemName": "speed_pid/Kd", "type": "int", "readAccess": true, "writeAccess": true },
-                { "name": "State", "systemName": "state", "type": "string array", "readAccess": true, "writeAccess": false },
-                { "name": "Stop Command", "systemName": "stop_command", "type": "string", "readAccess": true, "writeAccess": true },
-                { "name": "Stop Commands", "systemName": "stop_commands", "type": "string array", "readAccess": true, "writeAccess": false },
-                { "name": "Time SP", "systemName": "time_sp", "type": "int", "readAccess": true, "writeAccess": true }
+                { "name": "Command", "systemName": "command", "type": "string", "readAccess": false, "writeAccess": true,
+                  "description": [
+                      "Sends a command to the motor controller. See `commands` for a list of",
+                      "possible values."
+                  ]
+                },
+                { "name": "Commands", "systemName": "commands", "type": "string array", "readAccess": true, "writeAccess": false,
+                  "description": [
+                      "Returns a space separated list of commands that are supported by the motor",
+                      "controller. Possible values are `run-forever`, `run-to-abs-pos`, `run-to-rel-pos`,",
+                      "`run-timed`, `run-direct`, `stop` and `reset`. Not all commands may be supported.",
+                      "`run-forever` will cause the motor to run until another command is sent.",
+                      "`run-to-abs-pos` will run to an absolute position specified by `position_sp`",
+                      "and then stop using the command specified in `stop_command`.",
+                      "`run-to-rel-pos` will run to a position relative to the current `position` value.",
+                      "The new position will be current `position` + `position_sp`. When the new",
+                      "position is reached, the motor will stop using the command specified by `stop_command`.",
+                      "`run-timed` will run the motor for the amount of time specified in `time_sp`",
+                      "and then stop the motor using the command specified by `stop_command`.",
+                      "`run-direct` will run the motor at the duty cycle specified by `duty_cycle_sp`.",
+                      "Unlike other run commands, changing `duty_cycle_sp` while running *will*",
+                      "take effect immediately.",
+                      "`stop` will stop any of the run commands before they are complete using the",
+                      "command specified by `stop_command`.",
+                      "`reset` will reset all of the motor parameter attributes to their default value.",
+                      "This will also have the effect of stopping the motor."
+                  ]
+                },
+                { "name": "Count Per Rot", "systemName": "count_per_rot", "type": "int", "readAccess": true, "writeAccess": false,
+                  "description": [
+                      "Returns the number of tacho counts in one rotation of the motor. Tacho counts",
+                      "are used by the position and speed attributes, so you can use this value",
+                      "to convert rotations or degrees to tacho counts. In the case of linear",
+                      "actuators, the units here will be counts per centimeter."
+                  ]
+                },
+                { "name": "Driver Name", "systemName": "driver_name", "type": "string", "readAccess": true, "writeAccess": false,
+                  "description": [
+                      "Returns the name of the driver that provides this tacho motor device."
+                  ]
+                },
+                { "name": "Duty Cycle", "systemName": "duty_cycle", "type": "int", "readAccess": true, "writeAccess": false,
+                  "description": [
+                      "Returns the current duty cycle of the motor. Units are percent. Values",
+                      "are -100 to 100."
+                  ]
+                },
+                { "name": "Duty Cycle SP", "systemName": "duty_cycle_sp", "type": "int", "readAccess": true, "writeAccess": true,
+                  "description": [
+                      "Writing sets the duty cycle setpoint. Reading returns the current value.",
+                      "Units are in percent. Valid values are -100 to 100. A negative value causes",
+                      "the motor to rotate in reverse. This value is only used when `speed_regulation`",
+                      "is off."
+                  ]
+                },
+                { "name": "Encoder Polarity", "systemName": "encoder_polarity", "type": "string", "readAccess": true, "writeAccess": true,
+                  "description": [
+                      "Sets the polarity of the rotary encoder. This is an advanced feature to all",
+                      "use of motors that send inverted encoder signals to the EV3. This should",
+                      "be set correctly by the driver of a device. It You only need to change this",
+                      "value if you are using a unsupported device. Valid values are `normal` and",
+                      "`inverted`."
+                  ]
+                },
+                { "name": "Polarity", "systemName": "polarity", "type": "string", "readAccess": true, "writeAccess": true,
+                  "description": [
+                      "Sets the polarity of the motor. With `normal` polarity, a positive duty",
+                      "cycle will cause the motor to rotate clockwise. With `inverted` polarity,",
+                      "a positive duty cycle will cause the motor to rotate counter-clockwise.",
+                      "Valid values are `normal` and `inverted`."
+                  ]
+                },
+                { "name": "Port Name", "systemName": "port_name", "type": "string", "readAccess": true, "writeAccess": false,
+                  "description": [
+                      "Returns the name of the port that the motor is connected to."
+                  ]
+                },
+                { "name": "Position", "systemName": "position", "type": "int", "readAccess": true, "writeAccess": true,
+                  "description": [
+                      "Returns the current position of the motor in pulses of the rotary",
+                      "encoder. When the motor rotates clockwise, the position will increase.",
+                      "Likewise, rotating counter-clockwise causes the position to decrease.",
+                      "Writing will set the position to that value."
+                  ]
+                },
+                { "name": "Position P", "systemName": "hold_pid/Kp", "type": "int", "readAccess": true, "writeAccess": true,
+                  "description": [
+                      "The proportional constant for the position PID."
+                  ]
+                },
+                { "name": "Position I", "systemName": "hold_pid/Ki", "type": "int", "readAccess": true, "writeAccess": true,
+                  "description": [
+                      "The integral constant for the position PID."
+                  ]
+                },
+                { "name": "Position D", "systemName": "hold_pid/Kd", "type": "int", "readAccess": true, "writeAccess": true,
+                  "description": [
+                      "The derivative constant for the position PID."
+                  ]
+                },
+                { "name": "Position SP", "systemName": "position_sp", "type": "int", "readAccess": true, "writeAccess": true,
+                  "description": [
+                      "Writing specifies the target position for the `run-to-abs-pos` and `run-to-rel-pos`",
+                      "commands. Reading returns the current value. Units are in tacho counts. You",
+                      "can use the value returned by `counts_per_rot` to convert tacho counts to/from",
+                      "rotations or degrees."
+                  ]
+                },
+                { "name": "Speed", "systemName": "speed", "type": "int", "readAccess": true, "writeAccess": false,
+                  "description": [
+                      "Returns the current motor speed in tacho counts per second. Not, this is",
+                      "not necessarily degrees (although it is for LEGO motors). Use the `count_per_rot`",
+                      "attribute to convert this value to RPM or deg/sec."
+                  ]
+                },
+                { "name": "Speed SP", "systemName": "speed_sp", "type": "int", "readAccess": true, "writeAccess": true,
+                  "description": [
+                      "Writing sets the target speed in tacho counts per second used when `speed_regulation`",
+                      "is on. Reading returns the current value.  Use the `count_per_rot` attribute",
+                      "to convert RPM or deg/sec to tacho counts per second."
+                  ]
+                },
+                { "name": "Ramp Up SP", "systemName": "ramp_up_sp", "type": "int", "readAccess": true, "writeAccess": true,
+                  "description": [
+                      "Writing sets the ramp up setpoint. Reading returns the current value. Units",
+                      "are in milliseconds. When set to a value > 0, the motor will ramp the power",
+                      "sent to the motor from 0 to 100% duty cycle over the span of this setpoint",
+                      "when starting the motor. If the maximum duty cycle is limited by `duty_cycle_sp`",
+                      "or speed regulation, the actual ramp time duration will be less than the setpoint."
+                  ]
+                },
+                { "name": "Ramp Down SP", "systemName": "ramp_down_sp", "type": "int", "readAccess": true, "writeAccess": true,
+                  "description": [
+                      "Writing sets the ramp down setpoint. Reading returns the current value. Units",
+                      "are in milliseconds. When set to a value > 0, the motor will ramp the power",
+                      "sent to the motor from 100% duty cycle down to 0 over the span of this setpoint",
+                      "when stopping the motor. If the starting duty cycle is less than 100%, the",
+                      "ramp time duration will be less than the full span of the setpoint."
+                  ]
+                },
+                { "name": "Speed Regulation Enabled", "systemName": "speed_regulation", "type": "string", "readAccess": true, "writeAccess": true,
+                  "description": [
+                      "Turns speed regulation on or off. If speed regulation is on, the motor",
+                      "controller will vary the power supplied to the motor to try to maintain the",
+                      "speed specified in `speed_sp`. If speed regulation is off, the controller",
+                      "will use the power specified in `duty_cycle_sp`. Valid values are `on` and",
+                      "`off`."
+                  ]
+                },
+                { "name": "Speed Regulation P", "systemName": "speed_pid/Kp", "type": "int", "readAccess": true, "writeAccess": true,
+                  "description": [
+                      "The proportional constant for the speed regulation PID."
+                  ]
+                },
+                { "name": "Speed Regulation I", "systemName": "speed_pid/Ki", "type": "int", "readAccess": true, "writeAccess": true,
+                  "description": [
+                      "The integral constant for the speed regulation PID."
+                  ]
+                },
+                { "name": "Speed Regulation D", "systemName": "speed_pid/Kd", "type": "int", "readAccess": true, "writeAccess": true,
+                  "description": [
+                      "The derivative constant for the speed regulation PID."
+                  ]
+                },
+                { "name": "State", "systemName": "state", "type": "string array", "readAccess": true, "writeAccess": false,
+                  "description": [
+                      "Reading returns a space separated list of state flags. Possible flags are",
+                      "`running`, `ramping` `holding` and `stalled`."
+                  ]
+                },
+                { "name": "Stop Command", "systemName": "stop_command", "type": "string", "readAccess": true, "writeAccess": true,
+                  "description": [
+                      "Reading returns the current stop command. Writing sets the stop command.",
+                      "The value determines the motors behavior when `command` is set to `stop`.",
+                      "Also, it determines the motors behavior when a run command completes. See",
+                      "`stop_commands` for a list of possible values."
+                  ]
+                },
+                { "name": "Stop Commands", "systemName": "stop_commands", "type": "string array", "readAccess": true, "writeAccess": false,
+                  "description": [
+                      "Returns a space-separated list of stop modes supported by the motor controller.",
+                      "Possible values are `coast`, `brake` and `hold`. `coast` means that power will",
+                      "be removed from the motor and it will freely coast to a stop. `brake` means",
+                      "that power will be removed from the motor and a passive electrical load will",
+                      "be placed on the motor. This is usually done by shorting the motor terminals",
+                      "together. This load will absorb the energy from the rotation of the motors and",
+                      "cause the motor to stop more quickly than coasting. `hold` does not remove",
+                      "power from the motor. Instead it actively try to hold the motor at the current",
+                      "position. If an external force tries to turn the motor, the motor will 'push",
+                      "back' to maintain its position."
+                  ]
+                },
+                { "name": "Time SP", "systemName": "time_sp", "type": "int", "readAccess": true, "writeAccess": true,
+                  "description": [
+                      "Writing specifies the amount of time the motor will run when using the",
+                      "`run-timed` command. Reading returns the current value. Units are in",
+                      "milliseconds."
+                  ]
+                }
             ],
             "propertyValues": [
                 {
@@ -85,23 +263,89 @@
         },
         "dcMotor": {
             "friendlyName": "DC Motor",
-            "description": "The DC motor class provides a uniform interface for using regular DC motors with no fancy controls or feedback. This includes LEGO MINDSTORMS RCX motors and LEGO Power Functions motors.",
+            "description": [
+                "The DC motor class provides a uniform interface for using regular DC motors",
+                "with no fancy controls or feedback. This includes LEGO MINDSTORMS RCX motors",
+                "and LEGO Power Functions motors."
+            ],
             "docsLink": "http://www.ev3dev.org/docs/drivers/dc-motor-class/",
             "systemClassName":  "dc-motor",
             "systemDeviceNameConvention":  "motor{0}",
             "systemProperties": [
-                { "name": "Command", "systemName": "command", "type": "string", "readAccess": false, "writeAccess": true },
-                { "name": "Commands", "systemName": "commands", "type": "string array", "readAccess": true, "writeAccess": false },
-                { "name": "Driver Name", "systemName": "driver_name", "type": "string", "readAccess": true, "writeAccess": false },
-                { "name": "Duty Cycle", "systemName": "duty_cycle", "type": "int", "readAccess": true, "writeAccess": false },
-                { "name": "Duty Cycle SP", "systemName": "duty_cycle_sp", "type": "int", "readAccess": true, "writeAccess": true },
-                { "name": "Polarity", "systemName": "polarity", "type": "string", "readAccess": true, "writeAccess": true },
-                { "name": "Port Name", "systemName": "port_name", "type": "string", "readAccess": true, "writeAccess": false },
-                { "name": "Ramp Down SP", "systemName": "ramp_down_sp", "type": "int", "readAccess": true, "writeAccess": true },
-                { "name": "Ramp Up SP", "systemName": "ramp_up_sp", "type": "int", "readAccess": true, "writeAccess": true },
-                { "name": "State", "systemName": "state", "type": "string array", "readAccess": true, "writeAccess": false },
-                { "name": "Stop Command", "systemName": "stop_command", "type": "string", "readAccess": false, "writeAccess": true },
-                { "name": "Stop Commands", "systemName": "stop_commands", "type": "string array", "readAccess": true, "writeAccess": false }
+                { "name": "Command", "systemName": "command", "type": "string", "readAccess": false, "writeAccess": true,
+                  "description": [
+                      "Sets the command for the motor. Possible values are `run-forever`, `run-timed` and",
+                      "`stop`. Not all commands may be supported, so be sure to check the contents",
+                      "of the `commands` attribute."
+                  ]
+                },
+                { "name": "Commands", "systemName": "commands", "type": "string array", "readAccess": true, "writeAccess": false,
+                  "description": [
+                      "Returns a space separated list of commands supported by the motor",
+                      "controller."
+                  ]
+                },
+                { "name": "Driver Name", "systemName": "driver_name", "type": "string", "readAccess": true, "writeAccess": false,
+                  "description": [
+                      "Returns the name of the motor driver that loaded this device. See the list",
+                      "of [supported devices] for a list of drivers."
+                  ]
+                },
+                { "name": "Duty Cycle", "systemName": "duty_cycle", "type": "int", "readAccess": true, "writeAccess": false,
+                  "description": [
+                      "Shows the current duty cycle of the PWM signal sent to the motor. Values",
+                      "are -100 to 100 (-100% to 100%)."
+                  ]
+                },
+                { "name": "Duty Cycle SP", "systemName": "duty_cycle_sp", "type": "int", "readAccess": true, "writeAccess": true,
+                  "description": [
+                      "Writing sets the duty cycle setpoint of the PWM signal sent to the motor.",
+                      "Valid values are -100 to 100 (-100% to 100%). Reading returns the current",
+                      "setpoint."
+                  ]
+                },
+                { "name": "Polarity", "systemName": "polarity", "type": "string", "readAccess": true, "writeAccess": true,
+                  "description": [
+                      "Sets the polarity of the motor. Valid values are `normal` and `inverted`."
+                  ]
+                },
+                { "name": "Port Name", "systemName": "port_name", "type": "string", "readAccess": true, "writeAccess": false,
+                  "description": [
+                      "Returns the name of the port that the motor is connected to."
+                  ]
+                },
+                { "name": "Ramp Down SP", "systemName": "ramp_down_sp", "type": "int", "readAccess": true, "writeAccess": true,
+                  "description": [
+                      "Sets the time in milliseconds that it take the motor to ramp down from 100%",
+                      "to 0%. Valid values are 0 to 10000 (10 seconds). Default is 0."
+                  ]
+                },
+                { "name": "Ramp Up SP", "systemName": "ramp_up_sp", "type": "int", "readAccess": true, "writeAccess": true,
+                  "description": [
+                      "Sets the time in milliseconds that it take the motor to up ramp from 0% to",
+                      "100%. Valid values are 0 to 10000 (10 seconds). Default is 0."
+                  ]
+                },
+                { "name": "State", "systemName": "state", "type": "string array", "readAccess": true, "writeAccess": false,
+                  "description": [
+                      "Gets a space separated list of flags indicating the motor status. Possible",
+                      "flags are `running` and `ramping`. `running` indicates that the motor is",
+                      "powered. `ramping` indicates that the motor has not yet reached the",
+                      "`duty_cycle_sp`."
+                  ]
+                },
+                { "name": "Stop Command", "systemName": "stop_command", "type": "string", "readAccess": false, "writeAccess": true,
+                  "description": [
+                      "Sets the stop command that will be used when the motor stops. Read",
+                      "`stop_commands` to get the list of valid values."
+                  ]
+                },
+                { "name": "Stop Commands", "systemName": "stop_commands", "type": "string array", "readAccess": true, "writeAccess": false,
+                  "description": [
+                      "Gets a space separated list of stop commands. Valid values are `coast`",
+                      "and `brake`."
+                  ]
+                }
             ],
             "propertyValues": [
                 {
@@ -130,21 +374,91 @@
         },
         "servoMotor": {
             "friendlyName": "Servo Motor",
-            "description": "The servo motor class provides a uniform interface for using hobby type servo motors.",
+            "description": [
+                "The servo motor class provides a uniform interface for using hobby type",
+                "servo motors."
+            ],
             "docsLink": "http://www.ev3dev.org/docs/drivers/servo-motor-class/",
             "systemClassName":  "servo-motor",
             "systemDeviceNameConvention":  "motor{0}",
             "systemProperties": [
-                { "name": "Command", "systemName": "command", "type": "string", "readAccess": false, "writeAccess": true },
-                { "name": "Driver Name", "systemName": "driver_name", "type": "string", "readAccess": true, "writeAccess": false },
-                { "name": "Max Pulse SP", "systemName": "max_pulse_sp", "type": "int", "readAccess": true, "writeAccess": true },
-                { "name": "Mid Pulse SP", "systemName": "mid_pulse_sp", "type": "int", "readAccess": true, "writeAccess": true },
-                { "name": "Min Pulse SP", "systemName": "min_pulse_sp", "type": "int", "readAccess": true, "writeAccess": true },
-                { "name": "Polarity", "systemName": "polarity", "type": "string", "readAccess": true, "writeAccess": true },
-                { "name": "Port Name", "systemName": "port_name", "type": "string", "readAccess": true, "writeAccess": false },
-                { "name": "Position SP", "systemName": "position_sp", "type": "int", "readAccess": true, "writeAccess": true },
-                { "name": "Rate SP", "systemName": "rate_sp", "type": "int", "readAccess": true, "writeAccess": true },
-                { "name": "State", "systemName": "state", "type": "string array", "readAccess": true, "writeAccess": false }
+                { "name": "Command", "systemName": "command", "type": "string", "readAccess": false, "writeAccess": true,
+                  "description": [
+                      "Sets the command for the servo. Valid values are `run` and `float`. Setting",
+                      "to `run` will cause the servo to be driven to the position_sp set in the",
+                      "`position_sp` attribute. Setting to `float` will remove power from the motor."
+                  ]
+                },
+                { "name": "Driver Name", "systemName": "driver_name", "type": "string", "readAccess": true, "writeAccess": false,
+                  "description": [
+                      "Returns the name of the motor driver that loaded this device. See the list",
+                      "of [supported devices] for a list of drivers."
+                  ]
+                },
+                { "name": "Max Pulse SP", "systemName": "max_pulse_sp", "type": "int", "readAccess": true, "writeAccess": true,
+                  "description": [
+                      "Used to set the pulse size in milliseconds for the signal that tells the",
+                      "servo to drive to the maximum (clockwise) position_sp. Default value is 2400.",
+                      "Valid values are 2300 to 2700. You must write to the position_sp attribute for",
+                      "changes to this attribute to take effect."
+                  ]
+                },
+                { "name": "Mid Pulse SP", "systemName": "mid_pulse_sp", "type": "int", "readAccess": true, "writeAccess": true,
+                  "description": [
+                      "Used to set the pulse size in milliseconds for the signal that tells the",
+                      "servo to drive to the mid position_sp. Default value is 1500. Valid",
+                      "values are 1300 to 1700. For example, on a 180 degree servo, this would be",
+                      "90 degrees. On continuous rotation servo, this is the 'neutral' position_sp",
+                      "where the motor does not turn. You must write to the position_sp attribute for",
+                      "changes to this attribute to take effect."
+                  ]
+                },
+                { "name": "Min Pulse SP", "systemName": "min_pulse_sp", "type": "int", "readAccess": true, "writeAccess": true,
+                  "description": [
+                      "Used to set the pulse size in milliseconds for the signal that tells the",
+                      "servo to drive to the miniumum (counter-clockwise) position_sp. Default value",
+                      "is 600. Valid values are 300 to 700. You must write to the position_sp",
+                      "attribute for changes to this attribute to take effect."
+                  ]
+                },
+                { "name": "Polarity", "systemName": "polarity", "type": "string", "readAccess": true, "writeAccess": true,
+                  "description": [
+                      "Sets the polarity of the servo. Valid values are `normal` and `inverted`.",
+                      "Setting the value to `inverted` will cause the position_sp value to be",
+                      "inverted. i.e `-100` will correspond to `max_pulse_sp`, and `100` will",
+                      "correspond to `min_pulse_sp`."
+                  ]
+                },
+                { "name": "Port Name", "systemName": "port_name", "type": "string", "readAccess": true, "writeAccess": false,
+                  "description": [
+                      "Returns the name of the port that the motor is connected to."
+                  ]
+                },
+                { "name": "Position SP", "systemName": "position_sp", "type": "int", "readAccess": true, "writeAccess": true,
+                  "description": [
+                      "Reading returns the current position_sp of the servo. Writing instructs the",
+                      "servo to move to the specified position_sp. Units are percent. Valid values",
+                      "are -100 to 100 (-100% to 100%) where `-100` corresponds to `min_pulse_sp`,",
+                      "`0` corresponds to `mid_pulse_sp` and `100` corresponds to `max_pulse_sp`."
+                  ]
+                },
+                { "name": "Rate SP", "systemName": "rate_sp", "type": "int", "readAccess": true, "writeAccess": true,
+                  "description": [
+                      "Sets the rate_sp at which the servo travels from 0 to 100.0% (half of the full",
+                      "range of the servo). Units are in milliseconds. Example: Setting the rate_sp",
+                      "to 1000 means that it will take a 180 degree servo 2 second to move from 0",
+                      "to 180 degrees. Note: Some servo controllers may not support this in which",
+                      "case reading and writing will fail with `-EOPNOTSUPP`. In continuous rotation",
+                      "servos, this value will affect the rate_sp at which the speed ramps up or down."
+                  ]
+                },
+                { "name": "State", "systemName": "state", "type": "string array", "readAccess": true, "writeAccess": false,
+                  "description": [
+                      "Returns a space separated list of flags indicating the state of the servo.",
+                      "Possible values are:",
+                      "* `running`: Indicates that the motor is powered."
+                  ]
+                }
             ],
             "propertyValues": [
                 {
@@ -165,48 +479,136 @@
         },
         "led": {
             "friendlyName": "LED",
-            "description": "Any device controlled by the generic LED driver.",
+            "description": [
+                "Any device controlled by the generic LED driver."
+            ],
             "systemClassName":  "leds",
             "systemProperties": [
-                { "name": "Max Brightness", "systemName": "max_brightness", "type": "int", "readAccess": true, "writeAccess": false },
-                { "name": "Brightness", "systemName": "brightness", "type": "int", "readAccess": true, "writeAccess": true },
-                { "name": "Trigger", "systemName": "trigger", "type": "string", "readAccess": true, "writeAccess": true }
+                { "name": "Max Brightness", "systemName": "max_brightness", "type": "int", "readAccess": true, "writeAccess": false,
+                  "description": [
+                      "Gets the maximum allowable brightness value"
+                  ]
+                },
+                { "name": "Brightness", "systemName": "brightness", "type": "int", "readAccess": true, "writeAccess": true,
+                  "description": [
+                      "Sets the brightness level. Possible values are from 0 to `max_brightness`."
+                  ]
+                },
+                { "name": "Trigger", "systemName": "trigger", "type": "string", "readAccess": true, "writeAccess": true,
+                  "description": [
+                      "Sets the led trigger."
+                  ]
+                }
             ]
         },
         "sensor": {
             "friendlyName": "Sensor",
-            "description": "A generic interface to control most EV3 sensors.",
+            "description": [
+                "The sensor class provides a uniform interface for using most of the",
+                "sensors available for the EV3. The various underlying device drivers will",
+                "create a `lego-sensor` device for interacting with the sensors.",
+                "",
+                "Sensors are primarily controlled by setting the `mode` and monitored by",
+                "reading the `value<N>` attributes. Values can be converted to floating point",
+                "if needed by `value<N>` / 10.0 ^ `decimals`.",
+                "",
+                "Since the name of the `sensor<N>` device node does not correspond to the port",
+                "that a sensor is plugged in to, you must look at the `port_name` attribute if",
+                "you need to know which port a sensor is plugged in to. However, if you don't",
+                "have more than one sensor of each type, you can just look for a matching",
+                "`driver_name`. Then it will not matter which port a sensor is plugged in to - your",
+                "program will still work."
+            ],
             "docsLink":  "http://www.ev3dev.org/docs/drivers/lego-sensor-class/",
             "systemClassName":  "lego-sensor",
             "systemDeviceNameConvention":  "sensor{0}",
             "systemProperties": [
-                { "name": "Command", "systemName": "command", "type": "string", "readAccess": false, "writeAccess": true },
-                { "name": "Commands", "systemName": "commands", "type": "string array", "readAccess": true, "writeAccess": false },
-                { "name": "Decimals", "systemName": "decimals", "type": "int", "readAccess": true, "writeAccess": false },
-                { "name": "Driver Name", "systemName": "driver_name", "type": "string", "readAccess": true, "writeAccess": false },
-                { "name": "Mode", "systemName": "mode", "type": "string", "readAccess": true, "writeAccess": true },
-                { "name": "Modes", "systemName": "modes", "type": "string array", "readAccess": true, "writeAccess": false },
-                { "name": "Num Values", "systemName": "num_values", "type": "int", "readAccess": true, "writeAccess": false },
-                { "name": "Port Name", "systemName": "port_name", "type": "string", "readAccess": true, "writeAccess": false },
-                { "name": "Units", "systemName": "units", "type": "string", "readAccess": true, "writeAccess": false }
+                { "name": "Command", "systemName": "command", "type": "string", "readAccess": false, "writeAccess": true,
+                  "description": [
+                      "Sends a command to the sensor."
+                  ]
+                },
+                { "name": "Commands", "systemName": "commands", "type": "string array", "readAccess": true, "writeAccess": false,
+                  "description": [
+                      "Returns a space separated list of the valid commands for the sensor.",
+                      "Returns -EOPNOTSUPP if no commands are supported."
+                  ]
+                },
+                { "name": "Decimals", "systemName": "decimals", "type": "int", "readAccess": true, "writeAccess": false,
+                  "description": [
+                      "Returns the number of decimal places for the values in the `value<N>`",
+                      "attributes of the current mode."
+                  ]
+                },
+                { "name": "Driver Name", "systemName": "driver_name", "type": "string", "readAccess": true, "writeAccess": false,
+                  "description": [
+                      "Returns the name of the sensor device/driver. See the list of [supported",
+                      "sensors] for a complete list of drivers."
+                  ]
+                },
+                { "name": "Mode", "systemName": "mode", "type": "string", "readAccess": true, "writeAccess": true,
+                  "description": [
+                      "Returns the current mode. Writing one of the values returned by `modes`",
+                      "sets the sensor to that mode."
+                  ]
+                },
+                { "name": "Modes", "systemName": "modes", "type": "string array", "readAccess": true, "writeAccess": false,
+                  "description": [
+                      "Returns a space separated list of the valid modes for the sensor."
+                  ]
+                },
+                { "name": "Num Values", "systemName": "num_values", "type": "int", "readAccess": true, "writeAccess": false,
+                  "description": [
+                      "Returns the number of `value<N>` attributes that will return a valid value",
+                      "for the current mode."
+                  ]
+                },
+                { "name": "Port Name", "systemName": "port_name", "type": "string", "readAccess": true, "writeAccess": false,
+                  "description": [
+                      "Returns the name of the port that the sensor is connected to, e.g. `ev3:in1`.",
+                      "I2C sensors also include the I2C address (decimal), e.g. `ev3:in1:i2c8`."
+                  ]
+                },
+                { "name": "Units", "systemName": "units", "type": "string", "readAccess": true, "writeAccess": false,
+                  "description": [
+                      "Returns the units of the measured value for the current mode. May return",
+                      "empty string"
+                  ]
+                }
             ]
         },
         "i2cSensor": {
             "friendlyName": "I2C Sensor",
-            "description": "A generic interface to control I2C-type EV3 sensors.",
+            "description": [
+                "A generic interface to control I2C-type EV3 sensors."
+            ],
             "systemClassName":  "lego-sensor",
             "systemDeviceNameConvention":  "sensor{0}",
             "inheritance": [
                 "sensor"
             ],
             "systemProperties": [
-                { "name": "FW Version", "systemName": "fw_version", "type": "string", "readAccess": true, "writeAccess": false },
-                { "name": "Poll MS", "systemName": "poll_ms", "type": "int", "readAccess": true, "writeAccess": true }
+                { "name": "FW Version", "systemName": "fw_version", "type": "string", "readAccess": true, "writeAccess": false,
+                  "description": [
+                      "Returns the firmware version of the sensor if available. Currently only",
+                      "I2C/NXT sensors support this."
+                  ]
+                },
+                { "name": "Poll MS", "systemName": "poll_ms", "type": "int", "readAccess": true, "writeAccess": true,
+                  "description": [
+                      "Returns the polling period of the sensor in milliseconds. Writing sets the",
+                      "polling period. Setting to 0 disables polling. Minimum value is hard",
+                      "coded as 50 msec. Returns -EOPNOTSUPP if changing polling is not supported.",
+                      "Currently only I2C/NXT sensors support changing the polling period."
+                  ]
+                }
             ]
         },
         "colorSensor": {
             "friendlyName": "Color Sensor",
-            "description": "LEGO EV3 color sensor.",
+            "description": [
+                "LEGO EV3 color sensor."
+            ],
             "systemClassName":  "lego-sensor",
             "systemDeviceNameConvention":  "sensor{0}",
             "inheritance": [
@@ -228,7 +630,9 @@
         },
         "ultrasonicSensor": {
             "friendlyName": "Ultrasonic Sensor",
-            "description": "LEGO EV3 ultrasonic sensor.",
+            "description": [
+                "LEGO EV3 ultrasonic sensor."
+            ],
             "systemClassName":  "lego-sensor",
             "systemDeviceNameConvention":  "sensor{0}",
             "inheritance": [
@@ -251,7 +655,9 @@
         },
         "gyroSensor": {
             "friendlyName": "Gyro Sensor",
-            "description": "LEGO EV3 gyro sensor.",
+            "description": [
+                "LEGO EV3 gyro sensor."
+            ],
             "systemClassName":  "lego-sensor",
             "systemDeviceNameConvention":  "sensor{0}",
             "inheritance": [
@@ -272,7 +678,9 @@
         },
         "infraredSensor": {
             "friendlyName": "Infrared Sensor",
-            "description": "LEGO EV3 infrared sensor.",
+            "description": [
+                "LEGO EV3 infrared sensor."
+            ],
             "systemClassName":  "lego-sensor",
             "systemDeviceNameConvention":  "sensor{0}",
             "inheritance": [
@@ -294,11 +702,22 @@
         },
         "powerSupply": {
             "friendlyName": "Power Supply",
-            "description": "A generic interface to read data from the system's power_supply class. Uses the built-in legoev3-battery if none is specified.",
+            "description": [
+                "A generic interface to read data from the system's power_supply class.",
+                "Uses the built-in legoev3-battery if none is specified."
+            ],
             "systemClassName":  "power_supply",
             "systemProperties": [
-                { "name": "Measured Current", "systemName": "current_now", "type": "int", "readAccess": true, "writeAccess": false, "description": "The measured current that the battery is supplying (in microamps)" },
-                { "name": "Measured Voltage", "systemName": "voltage_now", "type": "int", "readAccess": true, "writeAccess": false, "description": "The measured voltage that the battery is supplying (in microvolts)" },
+                { "name": "Measured Current", "systemName": "current_now", "type": "int", "readAccess": true, "writeAccess": false,
+                  "description": [
+                      "The measured current that the battery is supplying (in microamps)"
+                  ]
+                },
+                { "name": "Measured Voltage", "systemName": "voltage_now", "type": "int", "readAccess": true, "writeAccess": false,
+                    "description": [
+                        "The measured voltage that the battery is supplying (in microvolts)"
+                    ]
+                },
                 { "name": "Max Voltage", "systemName": "voltage_max_design", "type": "int", "readAccess": true, "writeAccess": false },
                 { "name": "Min Voltage", "systemName": "voltage_min_design", "type": "int", "readAccess": true, "writeAccess": false },
                 { "name": "Technology", "systemName": "technology", "type": "string", "readAccess": true, "writeAccess": false },

--- a/autogen/templates/cpp_generic-class-description.liquid
+++ b/autogen/templates/cpp_generic-class-description.liquid
@@ -1,0 +1,3 @@
+{% for line in currentClass.description %}
+// {{ line }}{%
+endfor %}

--- a/autogen/templates/cpp_generic-declare-property-value.liquid
+++ b/autogen/templates/cpp_generic-declare-property-value.liquid
@@ -2,6 +2,6 @@
   assign prefix = prop.propertyName | downcase | underscore_spaces %}{%
   for value in prop.values %}{%
     assign cppName = value.name | downcase | underscore_non_wc %}
-    static const std::string {{ prefix }}_{{cppName}};{%
+  static const std::string {{ prefix }}_{{cppName}};{%
   endfor %}{%
 endfor %}

--- a/autogen/templates/cpp_generic-get-set.liquid
+++ b/autogen/templates/cpp_generic-get-set.liquid
@@ -1,7 +1,17 @@
-{% for prop in currentClass.systemProperties %}{%
+{% for prop in currentClass.systemProperties %}
+  // {{ prop.name }}:{%
+  if prop.readAccess %}{%
+    if prop.writeAccess %} read/write{%
+    else %} read-only{%
+    endif %}{%
+  else %} write-only{%
+  endif %}{%
+  for line in prop.description %}
+  // {{ line }}{%
+  endfor %}{%
   assign cppName = prop.name | downcase | underscore_spaces %}{%
   if prop.type contains 'array' %}
-    mode_set {{ cppName }}() const { return get_attr_set("{{ prop.systemName }}"); }{%
+  mode_set {{ cppName }}() const { return get_attr_set("{{ prop.systemName }}"); }{%
   else %}{%
     assign type = prop.type %}{%
     assign attr = type %}{%
@@ -9,10 +19,13 @@
       assign type = 'std::string' %}{%
     endif %}{%
     if prop.readAccess == true %}
-    {{ type }} {{ cppName }}() const { return get_attr_{{ attr }}("{{ prop.systemName }}"); }{%
+  {{ type }} {{ cppName }}() const { return get_attr_{{ attr }}("{{ prop.systemName }}"); }{%
     endif %}{%
     if prop.writeAccess == true %}
-    auto set_{{ cppName }}({{ type }} v) -> decltype(*this) { set_attr_{{ attr }}("{{ prop.systemName }}", v); return *this; }{%
+  auto set_{{ cppName }}({{ type }} v) -> decltype(*this) {
+    set_attr_{{ attr }}("{{ prop.systemName }}", v);
+    return *this;
+  }{%
     endif %}{%
-  endif %}{%
-endfor %}
+  endif %}
+{%endfor %}

--- a/autogen/templates/md_generic-class-description.liquid
+++ b/autogen/templates/md_generic-class-description.liquid
@@ -1,0 +1,3 @@
+{% for line in currentClass.description %}
+{{ line }}{%
+endfor %}

--- a/autogen/templates/md_generic-property-table.liquid
+++ b/autogen/templates/md_generic-property-table.liquid
@@ -2,5 +2,5 @@
 Property Name|Type|Accessibility|Description
 ---|---|---|---
 {% for prop in currentClass.systemProperties
-%}{{prop.name}}|{{prop.type}}|{{ '(readAccess ? "Read" : "") + (readAccess && writeAccess ? "/" : "") + (writeAccess ? "Write" : "")' | eval: prop }}|{{prop.description}}
+    %}{{prop.name}}|{{prop.type}}|{{ '(readAccess ? "Read" : "") + (readAccess && writeAccess ? "/" : "") + (writeAccess ? "Write" : "")' | eval: prop }}|{% for line in prop.description %} {{line}}{% endfor %}
 {% endfor %}

--- a/autogen/templates/python_generic-class-description.liquid
+++ b/autogen/templates/python_generic-class-description.liquid
@@ -1,0 +1,3 @@
+{% for line in currentClass.description %}
+                "{{ line }}\n"{%
+endfor %}

--- a/autogen/templates/python_generic-get-set.liquid
+++ b/autogen/templates/python_generic-get-set.liquid
@@ -2,9 +2,20 @@
 for prop in currentClass.systemProperties %}{%
   assign prop_name = prop.name | downcase | underscore_spaces %}{%
   if prop.readAccess == false %}
-            .add_property("{{ prop_name }}", no_getter<ev3::{{ class_name }}>, make_function(&ev3::{{ class_name }}::set_{{ prop_name }}, drop_return_value())){%
+            .add_property("{{ prop_name }}", no_getter<ev3::{{ class_name }}>, make_function(&ev3::{{ class_name }}::set_{{ prop_name }}, drop_return_value()){%
   else %}
             .add_property("{{ prop_name }}", &ev3::{{ class_name }}::{{ prop_name }}{%
-      if prop.writeAccess == true %}, make_function(&ev3::{{ class_name }}::set_{{ prop_name }}, drop_return_value()){% endif %}){%
-  endif%}{%
+      if prop.writeAccess == true %}, make_function(&ev3::{{ class_name }}::set_{{ prop_name }}, drop_return_value()){% endif %}{%
+  endif%},
+                    "{{ prop.name }}:{%
+  if prop.readAccess %}{%
+    if prop.writeAccess %} read/write{%
+    else %} read-only{%
+    endif %}{%
+  else %} write-only{%
+  endif %}\n\n"{%
+  for line in prop.description %}
+                    "{{ line }}\n"{%
+  endfor %}
+                    ){%
 endfor %}

--- a/cpp/ev3dev.h
+++ b/cpp/ev3dev.h
@@ -65,6 +65,7 @@ const port_type OUTPUT_D { "outD" }; //!< Motor port D
 
 //-----------------------------------------------------------------------------
 
+// Generic device class.
 class device
 {
 public:
@@ -96,6 +97,24 @@ protected:
 
 //-----------------------------------------------------------------------------
 
+//~autogen cpp_generic-class-description classes.sensor>currentClass
+
+// The sensor class provides a uniform interface for using most of the
+// sensors available for the EV3. The various underlying device drivers will
+// create a `lego-sensor` device for interacting with the sensors.
+// 
+// Sensors are primarily controlled by setting the `mode` and monitored by
+// reading the `value<N>` attributes. Values can be converted to floating point
+// if needed by `value<N>` / 10.0 ^ `decimals`.
+// 
+// Since the name of the `sensor<N>` device node does not correspond to the port
+// that a sensor is plugged in to, you must look at the `port_name` attribute if
+// you need to know which port a sensor is plugged in to. However, if you don't
+// have more than one sensor of each type, you can just look for a matching
+// `driver_name`. Then it will not matter which port a sensor is plugged in to - your
+// program will still work.
+
+//~autogen
 class sensor : protected device
 {
 public:
@@ -119,22 +138,70 @@ public:
   using device::connected;
   using device::device_index;
 
+  // Returns the value or values measured by the sensor. Check `num_values` to
+  // see how many values there are. Values with index >= num_values will return
+  // an error. The values are fixed point numbers, so check `decimals` to see
+  // if you need to divide to get the actual value.
   int   value(unsigned index=0) const;
+
+  // The value converted to float using `decimals`.
   float float_value(unsigned index=0) const;
+
+  // Human-readable name of the connected sensor.
   std::string type_name() const;
 
   //~autogen cpp_generic-get-set classes.sensor>currentClass
 
-    auto set_command(std::string v) -> decltype(*this) { set_attr_string("command", v); return *this; }
-    mode_set commands() const { return get_attr_set("commands"); }
-    int decimals() const { return get_attr_int("decimals"); }
-    std::string driver_name() const { return get_attr_string("driver_name"); }
-    std::string mode() const { return get_attr_string("mode"); }
-    auto set_mode(std::string v) -> decltype(*this) { set_attr_string("mode", v); return *this; }
-    mode_set modes() const { return get_attr_set("modes"); }
-    int num_values() const { return get_attr_int("num_values"); }
-    std::string port_name() const { return get_attr_string("port_name"); }
-    std::string units() const { return get_attr_string("units"); }
+  // Command: write-only
+  // Sends a command to the sensor.
+  auto set_command(std::string v) -> decltype(*this) {
+    set_attr_string("command", v);
+    return *this;
+  }
+
+  // Commands: read-only
+  // Returns a space separated list of the valid commands for the sensor.
+  // Returns -EOPNOTSUPP if no commands are supported.
+  mode_set commands() const { return get_attr_set("commands"); }
+
+  // Decimals: read-only
+  // Returns the number of decimal places for the values in the `value<N>`
+  // attributes of the current mode.
+  int decimals() const { return get_attr_int("decimals"); }
+
+  // Driver Name: read-only
+  // Returns the name of the sensor device/driver. See the list of [supported
+  // sensors] for a complete list of drivers.
+  std::string driver_name() const { return get_attr_string("driver_name"); }
+
+  // Mode: read/write
+  // Returns the current mode. Writing one of the values returned by `modes`
+  // sets the sensor to that mode.
+  std::string mode() const { return get_attr_string("mode"); }
+  auto set_mode(std::string v) -> decltype(*this) {
+    set_attr_string("mode", v);
+    return *this;
+  }
+
+  // Modes: read-only
+  // Returns a space separated list of the valid modes for the sensor.
+  mode_set modes() const { return get_attr_set("modes"); }
+
+  // Num Values: read-only
+  // Returns the number of `value<N>` attributes that will return a valid value
+  // for the current mode.
+  int num_values() const { return get_attr_int("num_values"); }
+
+  // Port Name: read-only
+  // Returns the name of the port that the sensor is connected to, e.g. `ev3:in1`.
+  // I2C sensors also include the I2C address (decimal), e.g. `ev3:in1:i2c8`.
+  std::string port_name() const { return get_attr_string("port_name"); }
+
+  // Units: read-only
+  // Returns the units of the measured value for the current mode. May return
+  // empty string
+  std::string units() const { return get_attr_string("units"); }
+
 
 //~autogen
 
@@ -146,6 +213,11 @@ protected:
 
 //-----------------------------------------------------------------------------
 
+//~autogen cpp_generic-class-description classes.i2cSensor>currentClass
+
+// A generic interface to control I2C-type EV3 sensors.
+
+//~autogen
 class i2c_sensor : public sensor
 {
 public:
@@ -154,15 +226,29 @@ public:
 
   //~autogen cpp_generic-get-set classes.i2cSensor>currentClass
 
-    std::string fw_version() const { return get_attr_string("fw_version"); }
-    int poll_ms() const { return get_attr_int("poll_ms"); }
-    auto set_poll_ms(int v) -> decltype(*this) { set_attr_int("poll_ms", v); return *this; }
+  // FW Version: read-only
+  // Returns the firmware version of the sensor if available. Currently only
+  // I2C/NXT sensors support this.
+  std::string fw_version() const { return get_attr_string("fw_version"); }
+
+  // Poll MS: read/write
+  // Returns the polling period of the sensor in milliseconds. Writing sets the
+  // polling period. Setting to 0 disables polling. Minimum value is hard
+  // coded as 50 msec. Returns -EOPNOTSUPP if changing polling is not supported.
+  // Currently only I2C/NXT sensors support changing the polling period.
+  int poll_ms() const { return get_attr_int("poll_ms"); }
+  auto set_poll_ms(int v) -> decltype(*this) {
+    set_attr_int("poll_ms", v);
+    return *this;
+  }
+
 
 //~autogen
 };
 
 //-----------------------------------------------------------------------------
 
+// Touch sensor
 class touch_sensor : public sensor
 {
 public:
@@ -171,6 +257,11 @@ public:
 
 //-----------------------------------------------------------------------------
 
+//~autogen cpp_generic-class-description classes.colorSensor>currentClass
+
+// LEGO EV3 color sensor.
+
+//~autogen
 class color_sensor : public sensor
 {
 public:
@@ -178,18 +269,23 @@ public:
 
   //~autogen cpp_generic-declare-property-value classes.colorSensor>currentClass
 
-    static const std::string mode_col_reflect;
-    static const std::string mode_col_ambient;
-    static const std::string mode_col_color;
-    static const std::string mode_ref_raw;
-    static const std::string mode_rgb_raw;
-    static const std::string mode_col_cal;
+  static const std::string mode_col_reflect;
+  static const std::string mode_col_ambient;
+  static const std::string mode_col_color;
+  static const std::string mode_ref_raw;
+  static const std::string mode_rgb_raw;
+  static const std::string mode_col_cal;
 
 //~autogen
 };
 
 //-----------------------------------------------------------------------------
 
+//~autogen cpp_generic-class-description classes.ultrasonicSensor>currentClass
+
+// LEGO EV3 ultrasonic sensor.
+
+//~autogen
 class ultrasonic_sensor : public sensor
 {
 public:
@@ -197,19 +293,24 @@ public:
 
   //~autogen cpp_generic-declare-property-value classes.ultrasonicSensor>currentClass
 
-    static const std::string mode_us_dist_cm;
-    static const std::string mode_us_dist_in;
-    static const std::string mode_us_listen;
-    static const std::string mode_us_si_cm;
-    static const std::string mode_us_si_in;
-    static const std::string mode_us_dc_cm;
-    static const std::string mode_us_dc_in;
+  static const std::string mode_us_dist_cm;
+  static const std::string mode_us_dist_in;
+  static const std::string mode_us_listen;
+  static const std::string mode_us_si_cm;
+  static const std::string mode_us_si_in;
+  static const std::string mode_us_dc_cm;
+  static const std::string mode_us_dc_in;
 
 //~autogen
 };
 
 //-----------------------------------------------------------------------------
 
+//~autogen cpp_generic-class-description classes.gyroSensor>currentClass
+
+// LEGO EV3 gyro sensor.
+
+//~autogen
 class gyro_sensor : public sensor
 {
 public:
@@ -217,17 +318,22 @@ public:
 
   //~autogen cpp_generic-declare-property-value classes.gyroSensor>currentClass
 
-    static const std::string mode_gyro_ang;
-    static const std::string mode_gyro_rate;
-    static const std::string mode_gyro_fas;
-    static const std::string mode_gyro_g_a;
-    static const std::string mode_gyro_cal;
+  static const std::string mode_gyro_ang;
+  static const std::string mode_gyro_rate;
+  static const std::string mode_gyro_fas;
+  static const std::string mode_gyro_g_a;
+  static const std::string mode_gyro_cal;
 
 //~autogen
 };
 
 //-----------------------------------------------------------------------------
 
+//~autogen cpp_generic-class-description classes.infraredSensor>currentClass
+
+// LEGO EV3 infrared sensor.
+
+//~autogen
 class infrared_sensor : public sensor
 {
 public:
@@ -235,18 +341,26 @@ public:
 
   //~autogen cpp_generic-declare-property-value classes.infraredSensor>currentClass
 
-    static const std::string mode_ir_prox;
-    static const std::string mode_ir_seek;
-    static const std::string mode_ir_remote;
-    static const std::string mode_ir_rem_a;
-    static const std::string mode_ir_s_alt;
-    static const std::string mode_ir_cal;
+  static const std::string mode_ir_prox;
+  static const std::string mode_ir_seek;
+  static const std::string mode_ir_remote;
+  static const std::string mode_ir_rem_a;
+  static const std::string mode_ir_s_alt;
+  static const std::string mode_ir_cal;
 
 //~autogen
 };
 
 //-----------------------------------------------------------------------------
 
+//~autogen cpp_generic-class-description classes.motor>currentClass
+
+// The motor class provides a uniform interface for using motors with
+// positional and directional feedback such as the EV3 and NXT motors.
+// This feedback allows for precise control of the motors. This is the
+// most common type of motor, so we just call it `motor`.
+
+//~autogen
 class motor : protected device
 {
 public:
@@ -263,70 +377,271 @@ public:
 
   //~autogen cpp_generic-declare-property-value classes.motor>currentClass
 
-    static const std::string command_run_forever;
-    static const std::string command_run_to_abs_pos;
-    static const std::string command_run_to_rel_pos;
-    static const std::string command_run_timed;
-    static const std::string command_run_direct;
-    static const std::string command_stop;
-    static const std::string command_reset;
-    static const std::string encoder_polarity_normal;
-    static const std::string encoder_polarity_inverted;
-    static const std::string polarity_normal;
-    static const std::string polarity_inverted;
-    static const std::string speed_regulation_on;
-    static const std::string speed_regulation_off;
-    static const std::string stop_command_coast;
-    static const std::string stop_command_brake;
-    static const std::string stop_command_hold;
+  static const std::string command_run_forever;
+  static const std::string command_run_to_abs_pos;
+  static const std::string command_run_to_rel_pos;
+  static const std::string command_run_timed;
+  static const std::string command_run_direct;
+  static const std::string command_stop;
+  static const std::string command_reset;
+  static const std::string encoder_polarity_normal;
+  static const std::string encoder_polarity_inverted;
+  static const std::string polarity_normal;
+  static const std::string polarity_inverted;
+  static const std::string speed_regulation_on;
+  static const std::string speed_regulation_off;
+  static const std::string stop_command_coast;
+  static const std::string stop_command_brake;
+  static const std::string stop_command_hold;
 
 //~autogen
 
   //~autogen cpp_generic-get-set classes.motor>currentClass
 
-    auto set_command(std::string v) -> decltype(*this) { set_attr_string("command", v); return *this; }
-    mode_set commands() const { return get_attr_set("commands"); }
-    int count_per_rot() const { return get_attr_int("count_per_rot"); }
-    std::string driver_name() const { return get_attr_string("driver_name"); }
-    int duty_cycle() const { return get_attr_int("duty_cycle"); }
-    int duty_cycle_sp() const { return get_attr_int("duty_cycle_sp"); }
-    auto set_duty_cycle_sp(int v) -> decltype(*this) { set_attr_int("duty_cycle_sp", v); return *this; }
-    std::string encoder_polarity() const { return get_attr_string("encoder_polarity"); }
-    auto set_encoder_polarity(std::string v) -> decltype(*this) { set_attr_string("encoder_polarity", v); return *this; }
-    std::string polarity() const { return get_attr_string("polarity"); }
-    auto set_polarity(std::string v) -> decltype(*this) { set_attr_string("polarity", v); return *this; }
-    std::string port_name() const { return get_attr_string("port_name"); }
-    int position() const { return get_attr_int("position"); }
-    auto set_position(int v) -> decltype(*this) { set_attr_int("position", v); return *this; }
-    int position_p() const { return get_attr_int("hold_pid/Kp"); }
-    auto set_position_p(int v) -> decltype(*this) { set_attr_int("hold_pid/Kp", v); return *this; }
-    int position_i() const { return get_attr_int("hold_pid/Ki"); }
-    auto set_position_i(int v) -> decltype(*this) { set_attr_int("hold_pid/Ki", v); return *this; }
-    int position_d() const { return get_attr_int("hold_pid/Kd"); }
-    auto set_position_d(int v) -> decltype(*this) { set_attr_int("hold_pid/Kd", v); return *this; }
-    int position_sp() const { return get_attr_int("position_sp"); }
-    auto set_position_sp(int v) -> decltype(*this) { set_attr_int("position_sp", v); return *this; }
-    int speed() const { return get_attr_int("speed"); }
-    int speed_sp() const { return get_attr_int("speed_sp"); }
-    auto set_speed_sp(int v) -> decltype(*this) { set_attr_int("speed_sp", v); return *this; }
-    int ramp_up_sp() const { return get_attr_int("ramp_up_sp"); }
-    auto set_ramp_up_sp(int v) -> decltype(*this) { set_attr_int("ramp_up_sp", v); return *this; }
-    int ramp_down_sp() const { return get_attr_int("ramp_down_sp"); }
-    auto set_ramp_down_sp(int v) -> decltype(*this) { set_attr_int("ramp_down_sp", v); return *this; }
-    std::string speed_regulation_enabled() const { return get_attr_string("speed_regulation"); }
-    auto set_speed_regulation_enabled(std::string v) -> decltype(*this) { set_attr_string("speed_regulation", v); return *this; }
-    int speed_regulation_p() const { return get_attr_int("speed_pid/Kp"); }
-    auto set_speed_regulation_p(int v) -> decltype(*this) { set_attr_int("speed_pid/Kp", v); return *this; }
-    int speed_regulation_i() const { return get_attr_int("speed_pid/Ki"); }
-    auto set_speed_regulation_i(int v) -> decltype(*this) { set_attr_int("speed_pid/Ki", v); return *this; }
-    int speed_regulation_d() const { return get_attr_int("speed_pid/Kd"); }
-    auto set_speed_regulation_d(int v) -> decltype(*this) { set_attr_int("speed_pid/Kd", v); return *this; }
-    mode_set state() const { return get_attr_set("state"); }
-    std::string stop_command() const { return get_attr_string("stop_command"); }
-    auto set_stop_command(std::string v) -> decltype(*this) { set_attr_string("stop_command", v); return *this; }
-    mode_set stop_commands() const { return get_attr_set("stop_commands"); }
-    int time_sp() const { return get_attr_int("time_sp"); }
-    auto set_time_sp(int v) -> decltype(*this) { set_attr_int("time_sp", v); return *this; }
+  // Command: write-only
+  // Sends a command to the motor controller. See `commands` for a list of
+  // possible values.
+  auto set_command(std::string v) -> decltype(*this) {
+    set_attr_string("command", v);
+    return *this;
+  }
+
+  // Commands: read-only
+  // Returns a space separated list of commands that are supported by the motor
+  // controller. Possible values are `run-forever`, `run-to-abs-pos`, `run-to-rel-pos`,
+  // `run-timed`, `run-direct`, `stop` and `reset`. Not all commands may be supported.
+  // `run-forever` will cause the motor to run until another command is sent.
+  // `run-to-abs-pos` will run to an absolute position specified by `position_sp`
+  // and then stop using the command specified in `stop_command`.
+  // `run-to-rel-pos` will run to a position relative to the current `position` value.
+  // The new position will be current `position` + `position_sp`. When the new
+  // position is reached, the motor will stop using the command specified by `stop_command`.
+  // `run-timed` will run the motor for the amount of time specified in `time_sp`
+  // and then stop the motor using the command specified by `stop_command`.
+  // `run-direct` will run the motor at the duty cycle specified by `duty_cycle_sp`.
+  // Unlike other run commands, changing `duty_cycle_sp` while running *will*
+  // take effect immediately.
+  // `stop` will stop any of the run commands before they are complete using the
+  // command specified by `stop_command`.
+  // `reset` will reset all of the motor parameter attributes to their default value.
+  // This will also have the effect of stopping the motor.
+  mode_set commands() const { return get_attr_set("commands"); }
+
+  // Count Per Rot: read-only
+  // Returns the number of tacho counts in one rotation of the motor. Tacho counts
+  // are used by the position and speed attributes, so you can use this value
+  // to convert rotations or degrees to tacho counts. In the case of linear
+  // actuators, the units here will be counts per centimeter.
+  int count_per_rot() const { return get_attr_int("count_per_rot"); }
+
+  // Driver Name: read-only
+  // Returns the name of the driver that provides this tacho motor device.
+  std::string driver_name() const { return get_attr_string("driver_name"); }
+
+  // Duty Cycle: read-only
+  // Returns the current duty cycle of the motor. Units are percent. Values
+  // are -100 to 100.
+  int duty_cycle() const { return get_attr_int("duty_cycle"); }
+
+  // Duty Cycle SP: read/write
+  // Writing sets the duty cycle setpoint. Reading returns the current value.
+  // Units are in percent. Valid values are -100 to 100. A negative value causes
+  // the motor to rotate in reverse. This value is only used when `speed_regulation`
+  // is off.
+  int duty_cycle_sp() const { return get_attr_int("duty_cycle_sp"); }
+  auto set_duty_cycle_sp(int v) -> decltype(*this) {
+    set_attr_int("duty_cycle_sp", v);
+    return *this;
+  }
+
+  // Encoder Polarity: read/write
+  // Sets the polarity of the rotary encoder. This is an advanced feature to all
+  // use of motors that send inverted encoder signals to the EV3. This should
+  // be set correctly by the driver of a device. It You only need to change this
+  // value if you are using a unsupported device. Valid values are `normal` and
+  // `inverted`.
+  std::string encoder_polarity() const { return get_attr_string("encoder_polarity"); }
+  auto set_encoder_polarity(std::string v) -> decltype(*this) {
+    set_attr_string("encoder_polarity", v);
+    return *this;
+  }
+
+  // Polarity: read/write
+  // Sets the polarity of the motor. With `normal` polarity, a positive duty
+  // cycle will cause the motor to rotate clockwise. With `inverted` polarity,
+  // a positive duty cycle will cause the motor to rotate counter-clockwise.
+  // Valid values are `normal` and `inverted`.
+  std::string polarity() const { return get_attr_string("polarity"); }
+  auto set_polarity(std::string v) -> decltype(*this) {
+    set_attr_string("polarity", v);
+    return *this;
+  }
+
+  // Port Name: read-only
+  // Returns the name of the port that the motor is connected to.
+  std::string port_name() const { return get_attr_string("port_name"); }
+
+  // Position: read/write
+  // Returns the current position of the motor in pulses of the rotary
+  // encoder. When the motor rotates clockwise, the position will increase.
+  // Likewise, rotating counter-clockwise causes the position to decrease.
+  // Writing will set the position to that value.
+  int position() const { return get_attr_int("position"); }
+  auto set_position(int v) -> decltype(*this) {
+    set_attr_int("position", v);
+    return *this;
+  }
+
+  // Position P: read/write
+  // The proportional constant for the position PID.
+  int position_p() const { return get_attr_int("hold_pid/Kp"); }
+  auto set_position_p(int v) -> decltype(*this) {
+    set_attr_int("hold_pid/Kp", v);
+    return *this;
+  }
+
+  // Position I: read/write
+  // The integral constant for the position PID.
+  int position_i() const { return get_attr_int("hold_pid/Ki"); }
+  auto set_position_i(int v) -> decltype(*this) {
+    set_attr_int("hold_pid/Ki", v);
+    return *this;
+  }
+
+  // Position D: read/write
+  // The derivative constant for the position PID.
+  int position_d() const { return get_attr_int("hold_pid/Kd"); }
+  auto set_position_d(int v) -> decltype(*this) {
+    set_attr_int("hold_pid/Kd", v);
+    return *this;
+  }
+
+  // Position SP: read/write
+  // Writing specifies the target position for the `run-to-abs-pos` and `run-to-rel-pos`
+  // commands. Reading returns the current value. Units are in tacho counts. You
+  // can use the value returned by `counts_per_rot` to convert tacho counts to/from
+  // rotations or degrees.
+  int position_sp() const { return get_attr_int("position_sp"); }
+  auto set_position_sp(int v) -> decltype(*this) {
+    set_attr_int("position_sp", v);
+    return *this;
+  }
+
+  // Speed: read-only
+  // Returns the current motor speed in tacho counts per second. Not, this is
+  // not necessarily degrees (although it is for LEGO motors). Use the `count_per_rot`
+  // attribute to convert this value to RPM or deg/sec.
+  int speed() const { return get_attr_int("speed"); }
+
+  // Speed SP: read/write
+  // Writing sets the target speed in tacho counts per second used when `speed_regulation`
+  // is on. Reading returns the current value.  Use the `count_per_rot` attribute
+  // to convert RPM or deg/sec to tacho counts per second.
+  int speed_sp() const { return get_attr_int("speed_sp"); }
+  auto set_speed_sp(int v) -> decltype(*this) {
+    set_attr_int("speed_sp", v);
+    return *this;
+  }
+
+  // Ramp Up SP: read/write
+  // Writing sets the ramp up setpoint. Reading returns the current value. Units
+  // are in milliseconds. When set to a value > 0, the motor will ramp the power
+  // sent to the motor from 0 to 100% duty cycle over the span of this setpoint
+  // when starting the motor. If the maximum duty cycle is limited by `duty_cycle_sp`
+  // or speed regulation, the actual ramp time duration will be less than the setpoint.
+  int ramp_up_sp() const { return get_attr_int("ramp_up_sp"); }
+  auto set_ramp_up_sp(int v) -> decltype(*this) {
+    set_attr_int("ramp_up_sp", v);
+    return *this;
+  }
+
+  // Ramp Down SP: read/write
+  // Writing sets the ramp down setpoint. Reading returns the current value. Units
+  // are in milliseconds. When set to a value > 0, the motor will ramp the power
+  // sent to the motor from 100% duty cycle down to 0 over the span of this setpoint
+  // when stopping the motor. If the starting duty cycle is less than 100%, the
+  // ramp time duration will be less than the full span of the setpoint.
+  int ramp_down_sp() const { return get_attr_int("ramp_down_sp"); }
+  auto set_ramp_down_sp(int v) -> decltype(*this) {
+    set_attr_int("ramp_down_sp", v);
+    return *this;
+  }
+
+  // Speed Regulation Enabled: read/write
+  // Turns speed regulation on or off. If speed regulation is on, the motor
+  // controller will vary the power supplied to the motor to try to maintain the
+  // speed specified in `speed_sp`. If speed regulation is off, the controller
+  // will use the power specified in `duty_cycle_sp`. Valid values are `on` and
+  // `off`.
+  std::string speed_regulation_enabled() const { return get_attr_string("speed_regulation"); }
+  auto set_speed_regulation_enabled(std::string v) -> decltype(*this) {
+    set_attr_string("speed_regulation", v);
+    return *this;
+  }
+
+  // Speed Regulation P: read/write
+  // The proportional constant for the speed regulation PID.
+  int speed_regulation_p() const { return get_attr_int("speed_pid/Kp"); }
+  auto set_speed_regulation_p(int v) -> decltype(*this) {
+    set_attr_int("speed_pid/Kp", v);
+    return *this;
+  }
+
+  // Speed Regulation I: read/write
+  // The integral constant for the speed regulation PID.
+  int speed_regulation_i() const { return get_attr_int("speed_pid/Ki"); }
+  auto set_speed_regulation_i(int v) -> decltype(*this) {
+    set_attr_int("speed_pid/Ki", v);
+    return *this;
+  }
+
+  // Speed Regulation D: read/write
+  // The derivative constant for the speed regulation PID.
+  int speed_regulation_d() const { return get_attr_int("speed_pid/Kd"); }
+  auto set_speed_regulation_d(int v) -> decltype(*this) {
+    set_attr_int("speed_pid/Kd", v);
+    return *this;
+  }
+
+  // State: read-only
+  // Reading returns a space separated list of state flags. Possible flags are
+  // `running`, `ramping` `holding` and `stalled`.
+  mode_set state() const { return get_attr_set("state"); }
+
+  // Stop Command: read/write
+  // Reading returns the current stop command. Writing sets the stop command.
+  // The value determines the motors behavior when `command` is set to `stop`.
+  // Also, it determines the motors behavior when a run command completes. See
+  // `stop_commands` for a list of possible values.
+  std::string stop_command() const { return get_attr_string("stop_command"); }
+  auto set_stop_command(std::string v) -> decltype(*this) {
+    set_attr_string("stop_command", v);
+    return *this;
+  }
+
+  // Stop Commands: read-only
+  // Returns a space-separated list of stop modes supported by the motor controller.
+  // Possible values are `coast`, `brake` and `hold`. `coast` means that power will
+  // be removed from the motor and it will freely coast to a stop. `brake` means
+  // that power will be removed from the motor and a passive electrical load will
+  // be placed on the motor. This is usually done by shorting the motor terminals
+  // together. This load will absorb the energy from the rotation of the motors and
+  // cause the motor to stop more quickly than coasting. `hold` does not remove
+  // power from the motor. Instead it actively try to hold the motor at the current
+  // position. If an external force tries to turn the motor, the motor will 'push
+  // back' to maintain its position.
+  mode_set stop_commands() const { return get_attr_set("stop_commands"); }
+
+  // Time SP: read/write
+  // Writing specifies the amount of time the motor will run when using the
+  // `run-timed` command. Reading returns the current value. Units are in
+  // milliseconds.
+  int time_sp() const { return get_attr_int("time_sp"); }
+  auto set_time_sp(int v) -> decltype(*this) {
+    set_attr_int("time_sp", v);
+    return *this;
+  }
+
 
 //~autogen
 
@@ -350,6 +665,7 @@ protected:
 
 //-----------------------------------------------------------------------------
 
+// EV3 medium motor
 class medium_motor : public motor
 {
 public:
@@ -358,6 +674,7 @@ public:
 
 //-----------------------------------------------------------------------------
 
+// EV3 large motor
 class large_motor : public motor
 {
 public:
@@ -366,6 +683,13 @@ public:
 
 //-----------------------------------------------------------------------------
 
+//~autogen cpp_generic-class-description classes.dcMotor>currentClass
+
+// The DC motor class provides a uniform interface for using regular DC motors
+// with no fancy controls or feedback. This includes LEGO MINDSTORMS RCX motors
+// and LEGO Power Functions motors.
+
+//~autogen
 class dc_motor : protected device
 {
 public:
@@ -376,34 +700,102 @@ public:
 
   //~autogen cpp_generic-declare-property-value classes.dcMotor>currentClass
 
-    static const std::string command_run_forever;
-    static const std::string command_run_timed;
-    static const std::string command_stop;
-    static const std::string polarity_normal;
-    static const std::string polarity_inverted;
-    static const std::string stop_command_coast;
-    static const std::string stop_command_brake;
+  static const std::string command_run_forever;
+  static const std::string command_run_timed;
+  static const std::string command_stop;
+  static const std::string polarity_normal;
+  static const std::string polarity_inverted;
+  static const std::string stop_command_coast;
+  static const std::string stop_command_brake;
 
 //~autogen
 
   //~autogen cpp_generic-get-set classes.dcMotor>currentClass
 
-    auto set_command(std::string v) -> decltype(*this) { set_attr_string("command", v); return *this; }
-    mode_set commands() const { return get_attr_set("commands"); }
-    std::string driver_name() const { return get_attr_string("driver_name"); }
-    int duty_cycle() const { return get_attr_int("duty_cycle"); }
-    int duty_cycle_sp() const { return get_attr_int("duty_cycle_sp"); }
-    auto set_duty_cycle_sp(int v) -> decltype(*this) { set_attr_int("duty_cycle_sp", v); return *this; }
-    std::string polarity() const { return get_attr_string("polarity"); }
-    auto set_polarity(std::string v) -> decltype(*this) { set_attr_string("polarity", v); return *this; }
-    std::string port_name() const { return get_attr_string("port_name"); }
-    int ramp_down_sp() const { return get_attr_int("ramp_down_sp"); }
-    auto set_ramp_down_sp(int v) -> decltype(*this) { set_attr_int("ramp_down_sp", v); return *this; }
-    int ramp_up_sp() const { return get_attr_int("ramp_up_sp"); }
-    auto set_ramp_up_sp(int v) -> decltype(*this) { set_attr_int("ramp_up_sp", v); return *this; }
-    mode_set state() const { return get_attr_set("state"); }
-    auto set_stop_command(std::string v) -> decltype(*this) { set_attr_string("stop_command", v); return *this; }
-    mode_set stop_commands() const { return get_attr_set("stop_commands"); }
+  // Command: write-only
+  // Sets the command for the motor. Possible values are `run-forever`, `run-timed` and
+  // `stop`. Not all commands may be supported, so be sure to check the contents
+  // of the `commands` attribute.
+  auto set_command(std::string v) -> decltype(*this) {
+    set_attr_string("command", v);
+    return *this;
+  }
+
+  // Commands: read-only
+  // Returns a space separated list of commands supported by the motor
+  // controller.
+  mode_set commands() const { return get_attr_set("commands"); }
+
+  // Driver Name: read-only
+  // Returns the name of the motor driver that loaded this device. See the list
+  // of [supported devices] for a list of drivers.
+  std::string driver_name() const { return get_attr_string("driver_name"); }
+
+  // Duty Cycle: read-only
+  // Shows the current duty cycle of the PWM signal sent to the motor. Values
+  // are -100 to 100 (-100% to 100%).
+  int duty_cycle() const { return get_attr_int("duty_cycle"); }
+
+  // Duty Cycle SP: read/write
+  // Writing sets the duty cycle setpoint of the PWM signal sent to the motor.
+  // Valid values are -100 to 100 (-100% to 100%). Reading returns the current
+  // setpoint.
+  int duty_cycle_sp() const { return get_attr_int("duty_cycle_sp"); }
+  auto set_duty_cycle_sp(int v) -> decltype(*this) {
+    set_attr_int("duty_cycle_sp", v);
+    return *this;
+  }
+
+  // Polarity: read/write
+  // Sets the polarity of the motor. Valid values are `normal` and `inverted`.
+  std::string polarity() const { return get_attr_string("polarity"); }
+  auto set_polarity(std::string v) -> decltype(*this) {
+    set_attr_string("polarity", v);
+    return *this;
+  }
+
+  // Port Name: read-only
+  // Returns the name of the port that the motor is connected to.
+  std::string port_name() const { return get_attr_string("port_name"); }
+
+  // Ramp Down SP: read/write
+  // Sets the time in milliseconds that it take the motor to ramp down from 100%
+  // to 0%. Valid values are 0 to 10000 (10 seconds). Default is 0.
+  int ramp_down_sp() const { return get_attr_int("ramp_down_sp"); }
+  auto set_ramp_down_sp(int v) -> decltype(*this) {
+    set_attr_int("ramp_down_sp", v);
+    return *this;
+  }
+
+  // Ramp Up SP: read/write
+  // Sets the time in milliseconds that it take the motor to up ramp from 0% to
+  // 100%. Valid values are 0 to 10000 (10 seconds). Default is 0.
+  int ramp_up_sp() const { return get_attr_int("ramp_up_sp"); }
+  auto set_ramp_up_sp(int v) -> decltype(*this) {
+    set_attr_int("ramp_up_sp", v);
+    return *this;
+  }
+
+  // State: read-only
+  // Gets a space separated list of flags indicating the motor status. Possible
+  // flags are `running` and `ramping`. `running` indicates that the motor is
+  // powered. `ramping` indicates that the motor has not yet reached the
+  // `duty_cycle_sp`.
+  mode_set state() const { return get_attr_set("state"); }
+
+  // Stop Command: write-only
+  // Sets the stop command that will be used when the motor stops. Read
+  // `stop_commands` to get the list of valid values.
+  auto set_stop_command(std::string v) -> decltype(*this) {
+    set_attr_string("stop_command", v);
+    return *this;
+  }
+
+  // Stop Commands: read-only
+  // Gets a space separated list of stop commands. Valid values are `coast`
+  // and `brake`.
+  mode_set stop_commands() const { return get_attr_set("stop_commands"); }
+
 
 //~autogen
 
@@ -421,6 +813,12 @@ protected:
 
 //-----------------------------------------------------------------------------
 
+//~autogen cpp_generic-class-description classes.servoMotor>currentClass
+
+// The servo motor class provides a uniform interface for using hobby type
+// servo motors.
+
+//~autogen
 class servo_motor : protected device
 {
 public:
@@ -431,31 +829,109 @@ public:
 
   //~autogen cpp_generic-declare-property-value classes.servoMotor>currentClass
 
-    static const std::string command_run;
-    static const std::string command_float;
-    static const std::string polarity_normal;
-    static const std::string polarity_inverted;
+  static const std::string command_run;
+  static const std::string command_float;
+  static const std::string polarity_normal;
+  static const std::string polarity_inverted;
 
 //~autogen
 
   //~autogen cpp_generic-get-set classes.servoMotor>currentClass
 
-    auto set_command(std::string v) -> decltype(*this) { set_attr_string("command", v); return *this; }
-    std::string driver_name() const { return get_attr_string("driver_name"); }
-    int max_pulse_sp() const { return get_attr_int("max_pulse_sp"); }
-    auto set_max_pulse_sp(int v) -> decltype(*this) { set_attr_int("max_pulse_sp", v); return *this; }
-    int mid_pulse_sp() const { return get_attr_int("mid_pulse_sp"); }
-    auto set_mid_pulse_sp(int v) -> decltype(*this) { set_attr_int("mid_pulse_sp", v); return *this; }
-    int min_pulse_sp() const { return get_attr_int("min_pulse_sp"); }
-    auto set_min_pulse_sp(int v) -> decltype(*this) { set_attr_int("min_pulse_sp", v); return *this; }
-    std::string polarity() const { return get_attr_string("polarity"); }
-    auto set_polarity(std::string v) -> decltype(*this) { set_attr_string("polarity", v); return *this; }
-    std::string port_name() const { return get_attr_string("port_name"); }
-    int position_sp() const { return get_attr_int("position_sp"); }
-    auto set_position_sp(int v) -> decltype(*this) { set_attr_int("position_sp", v); return *this; }
-    int rate_sp() const { return get_attr_int("rate_sp"); }
-    auto set_rate_sp(int v) -> decltype(*this) { set_attr_int("rate_sp", v); return *this; }
-    mode_set state() const { return get_attr_set("state"); }
+  // Command: write-only
+  // Sets the command for the servo. Valid values are `run` and `float`. Setting
+  // to `run` will cause the servo to be driven to the position_sp set in the
+  // `position_sp` attribute. Setting to `float` will remove power from the motor.
+  auto set_command(std::string v) -> decltype(*this) {
+    set_attr_string("command", v);
+    return *this;
+  }
+
+  // Driver Name: read-only
+  // Returns the name of the motor driver that loaded this device. See the list
+  // of [supported devices] for a list of drivers.
+  std::string driver_name() const { return get_attr_string("driver_name"); }
+
+  // Max Pulse SP: read/write
+  // Used to set the pulse size in milliseconds for the signal that tells the
+  // servo to drive to the maximum (clockwise) position_sp. Default value is 2400.
+  // Valid values are 2300 to 2700. You must write to the position_sp attribute for
+  // changes to this attribute to take effect.
+  int max_pulse_sp() const { return get_attr_int("max_pulse_sp"); }
+  auto set_max_pulse_sp(int v) -> decltype(*this) {
+    set_attr_int("max_pulse_sp", v);
+    return *this;
+  }
+
+  // Mid Pulse SP: read/write
+  // Used to set the pulse size in milliseconds for the signal that tells the
+  // servo to drive to the mid position_sp. Default value is 1500. Valid
+  // values are 1300 to 1700. For example, on a 180 degree servo, this would be
+  // 90 degrees. On continuous rotation servo, this is the 'neutral' position_sp
+  // where the motor does not turn. You must write to the position_sp attribute for
+  // changes to this attribute to take effect.
+  int mid_pulse_sp() const { return get_attr_int("mid_pulse_sp"); }
+  auto set_mid_pulse_sp(int v) -> decltype(*this) {
+    set_attr_int("mid_pulse_sp", v);
+    return *this;
+  }
+
+  // Min Pulse SP: read/write
+  // Used to set the pulse size in milliseconds for the signal that tells the
+  // servo to drive to the miniumum (counter-clockwise) position_sp. Default value
+  // is 600. Valid values are 300 to 700. You must write to the position_sp
+  // attribute for changes to this attribute to take effect.
+  int min_pulse_sp() const { return get_attr_int("min_pulse_sp"); }
+  auto set_min_pulse_sp(int v) -> decltype(*this) {
+    set_attr_int("min_pulse_sp", v);
+    return *this;
+  }
+
+  // Polarity: read/write
+  // Sets the polarity of the servo. Valid values are `normal` and `inverted`.
+  // Setting the value to `inverted` will cause the position_sp value to be
+  // inverted. i.e `-100` will correspond to `max_pulse_sp`, and `100` will
+  // correspond to `min_pulse_sp`.
+  std::string polarity() const { return get_attr_string("polarity"); }
+  auto set_polarity(std::string v) -> decltype(*this) {
+    set_attr_string("polarity", v);
+    return *this;
+  }
+
+  // Port Name: read-only
+  // Returns the name of the port that the motor is connected to.
+  std::string port_name() const { return get_attr_string("port_name"); }
+
+  // Position SP: read/write
+  // Reading returns the current position_sp of the servo. Writing instructs the
+  // servo to move to the specified position_sp. Units are percent. Valid values
+  // are -100 to 100 (-100% to 100%) where `-100` corresponds to `min_pulse_sp`,
+  // `0` corresponds to `mid_pulse_sp` and `100` corresponds to `max_pulse_sp`.
+  int position_sp() const { return get_attr_int("position_sp"); }
+  auto set_position_sp(int v) -> decltype(*this) {
+    set_attr_int("position_sp", v);
+    return *this;
+  }
+
+  // Rate SP: read/write
+  // Sets the rate_sp at which the servo travels from 0 to 100.0% (half of the full
+  // range of the servo). Units are in milliseconds. Example: Setting the rate_sp
+  // to 1000 means that it will take a 180 degree servo 2 second to move from 0
+  // to 180 degrees. Note: Some servo controllers may not support this in which
+  // case reading and writing will fail with `-EOPNOTSUPP`. In continuous rotation
+  // servos, this value will affect the rate_sp at which the speed ramps up or down.
+  int rate_sp() const { return get_attr_int("rate_sp"); }
+  auto set_rate_sp(int v) -> decltype(*this) {
+    set_attr_int("rate_sp", v);
+    return *this;
+  }
+
+  // State: read-only
+  // Returns a space separated list of flags indicating the state of the servo.
+  // Possible values are:
+  // * `running`: Indicates that the motor is powered.
+  mode_set state() const { return get_attr_set("state"); }
+
 
 //~autogen
 
@@ -469,6 +945,11 @@ public:
 
 //-----------------------------------------------------------------------------
 
+//~autogen cpp_generic-class-description classes.led>currentClass
+
+// Any device controlled by the generic LED driver.
+
+//~autogen
 class led : protected device
 {
 public:
@@ -478,11 +959,26 @@ public:
 
   //~autogen cpp_generic-get-set classes.led>currentClass
 
-    int max_brightness() const { return get_attr_int("max_brightness"); }
-    int brightness() const { return get_attr_int("brightness"); }
-    auto set_brightness(int v) -> decltype(*this) { set_attr_int("brightness", v); return *this; }
-    std::string trigger() const { return get_attr_string("trigger"); }
-    auto set_trigger(std::string v) -> decltype(*this) { set_attr_string("trigger", v); return *this; }
+  // Max Brightness: read-only
+  // Gets the maximum allowable brightness value
+  int max_brightness() const { return get_attr_int("max_brightness"); }
+
+  // Brightness: read/write
+  // Sets the brightness level. Possible values are from 0 to `max_brightness`.
+  int brightness() const { return get_attr_int("brightness"); }
+  auto set_brightness(int v) -> decltype(*this) {
+    set_attr_int("brightness", v);
+    return *this;
+  }
+
+  // Trigger: read/write
+  // Sets the led trigger.
+  std::string trigger() const { return get_attr_string("trigger"); }
+  auto set_trigger(std::string v) -> decltype(*this) {
+    set_attr_string("trigger", v);
+    return *this;
+  }
+
 
 //~autogen
 
@@ -513,6 +1009,12 @@ protected:
 
 //-----------------------------------------------------------------------------
 
+//~autogen cpp_generic-class-description classes.powerSupply>currentClass
+
+// A generic interface to read data from the system's power_supply class.
+// Uses the built-in legoev3-battery if none is specified.
+
+//~autogen
 class power_supply : protected device
 {
 public:
@@ -522,12 +1024,26 @@ public:
 
   //~autogen cpp_generic-get-set classes.powerSupply>currentClass
 
-    int measured_current() const { return get_attr_int("current_now"); }
-    int measured_voltage() const { return get_attr_int("voltage_now"); }
-    int max_voltage() const { return get_attr_int("voltage_max_design"); }
-    int min_voltage() const { return get_attr_int("voltage_min_design"); }
-    std::string technology() const { return get_attr_string("technology"); }
-    std::string type() const { return get_attr_string("type"); }
+  // Measured Current: read-only
+  // The measured current that the battery is supplying (in microamps)
+  int measured_current() const { return get_attr_int("current_now"); }
+
+  // Measured Voltage: read-only
+  // The measured voltage that the battery is supplying (in microvolts)
+  int measured_voltage() const { return get_attr_int("voltage_now"); }
+
+  // Max Voltage: read-only
+  int max_voltage() const { return get_attr_int("voltage_max_design"); }
+
+  // Min Voltage: read-only
+  int min_voltage() const { return get_attr_int("voltage_min_design"); }
+
+  // Technology: read-only
+  std::string technology() const { return get_attr_string("technology"); }
+
+  // Type: read-only
+  std::string type() const { return get_attr_string("type"); }
+
 
 //~autogen
 
@@ -539,6 +1055,7 @@ public:
 
 //-----------------------------------------------------------------------------
 
+// EV3 buttons
 class button
 {
 public:
@@ -568,6 +1085,7 @@ private:
 
 //-----------------------------------------------------------------------------
 
+// EV3 Sound
 class sound
 {
 public:
@@ -583,6 +1101,7 @@ public:
 
 //-----------------------------------------------------------------------------
 
+// EV3 LCD
 class lcd
 {
 public:
@@ -617,6 +1136,7 @@ private:
 
 //-----------------------------------------------------------------------------
 
+// EV3 remote control
 class remote_control
 {
 public:

--- a/wrapper-specification.md
+++ b/wrapper-specification.md
@@ -9,7 +9,7 @@ Because this specification is meant to be implemented in multiple languages, the
 Some concepts that apply to multiple classes are described as "abstracts". These abstract sections explain how the class should handle specific situations, and do not necessarily translate in to their own class in the wrapper.
 
 <!-- ~autogen autogen-header 'xml'>commentStyle -->
-<!-- Sections of the following code were auto-generated based on spec v0.9.2-pre, rev 2. -->
+<!-- Sections of the following code were auto-generated based on spec v0.9.2-pre, rev 3. -->
 <!-- ~autogen -->
 
 Implementation Notes (important)
@@ -22,6 +22,16 @@ Implementation Notes (important)
 
 `Motor` (class) : abstract "IO Device"
 -----
+
+<!-- ~autogen md_generic-class-description classes.motor>currentClass -->
+
+The motor class provides a uniform interface for using motors with
+positional and directional feedback such as the EV3 and NXT motors.
+This feedback allows for precise control of the motors. This is the
+most common type of motor, so we just call it `motor`.
+
+<!-- ~autogen -->
+
 ###Constructor:
 
 Argument Name|Type|Description
@@ -35,32 +45,33 @@ Driver Name|String|The motor driver that should be driving the target motor (gen
 
 Property Name|Type|Accessibility|Description
 ---|---|---|---
-Command|string|Write|
-Commands|string array|Read|
-Count Per Rot|int|Read|
-Driver Name|string|Read|
-Duty Cycle|int|Read|
-Duty Cycle SP|int|Read/Write|
-Encoder Polarity|string|Read/Write|
-Polarity|string|Read/Write|
-Port Name|string|Read|
-Position|int|Read/Write|
-Position P|int|Read/Write|
-Position I|int|Read/Write|
-Position D|int|Read/Write|
-Position SP|int|Read/Write|
-Speed|int|Read|
-Speed SP|int|Read/Write|
-Ramp Up SP|int|Read/Write|
-Ramp Down SP|int|Read/Write|
-Speed Regulation Enabled|string|Read/Write|
-Speed Regulation P|int|Read/Write|
-Speed Regulation I|int|Read/Write|
-Speed Regulation D|int|Read/Write|
-State|string array|Read|
-Stop Command|string|Read/Write|
-Stop Commands|string array|Read|
-Time SP|int|Read/Write|
+Command|string|Write| Sends a command to the motor controller. See `commands` for a list of possible values.
+Commands|string array|Read| Returns a space separated list of commands that are supported by the motor controller. Possible values are `run-forever`, `run-to-abs-pos`, `run-to-rel-pos`, `run-timed`, `run-direct`, `stop` and `reset`. Not all commands may be supported. `run-forever` will cause the motor to run until another command is sent. `run-to-abs-pos` will run to an absolute position specified by `position_sp` and then stop using the command specified in `stop_command`. `run-to-rel-pos` will run to a position relative to the current `position` value. The new position will be current `position` + `position_sp`. When the new position is reached, the motor will stop using the command specified by `stop_command`. `run-timed` will run the motor for the amount of time specified in `time_sp` and then stop the motor using the command specified by `stop_command`. `run-direct` will run the motor at the duty cycle specified by `duty_cycle_sp`. Unlike other run commands, changing `duty_cycle_sp` while running *will* take effect immediately. `stop` will stop any of the run commands before they are complete using the command specified by `stop_command`. `reset` will reset all of the motor parameter attributes to their default value. This will also have the effect of stopping the motor.
+Count Per Rot|int|Read| Returns the number of tacho counts in one rotation of the motor. Tacho counts are used by the position and speed attributes, so you can use this value to convert rotations or degrees to tacho counts. In the case of linear actuators, the units here will be counts per centimeter.
+Driver Name|string|Read| Returns the name of the driver that provides this tacho motor device.
+Duty Cycle|int|Read| Returns the current duty cycle of the motor. Units are percent. Values are -100 to 100.
+Duty Cycle SP|int|Read/Write| Writing sets the duty cycle setpoint. Reading returns the current value. Units are in percent. Valid values are -100 to 100. A negative value causes the motor to rotate in reverse. This value is only used when `speed_regulation` is off.
+Encoder Polarity|string|Read/Write| Sets the polarity of the rotary encoder. This is an advanced feature to all use of motors that send inverted encoder signals to the EV3. This should be set correctly by the driver of a device. It You only need to change this value if you are using a unsupported device. Valid values are `normal` and `inverted`.
+Polarity|string|Read/Write| Sets the polarity of the motor. With `normal` polarity, a positive duty cycle will cause the motor to rotate clockwise. With `inverted` polarity, a positive duty cycle will cause the motor to rotate counter-clockwise. Valid values are `normal` and `inverted`.
+Port Name|string|Read| Returns the name of the port that the motor is connected to.
+Position|int|Read/Write| Returns the current position of the motor in pulses of the rotary encoder. When the motor rotates clockwise, the position will increase. Likewise, rotating counter-clockwise causes the position to decrease. Writing will set the position to that value.
+Position P|int|Read/Write| The proportional constant for the position PID.
+Position I|int|Read/Write| The integral constant for the position PID.
+Position D|int|Read/Write| The derivative constant for the position PID.
+Position SP|int|Read/Write| Writing specifies the target position for the `run-to-abs-pos` and `run-to-rel-pos` commands. Reading returns the current value. Units are in tacho counts. You can use the value returned by `counts_per_rot` to convert tacho counts to/from rotations or degrees.
+Speed|int|Read| Returns the current motor speed in tacho counts per second. Not, this is not necessarily degrees (although it is for LEGO motors). Use the `count_per_rot` attribute to convert this value to RPM or deg/sec.
+Speed SP|int|Read/Write| Writing sets the target speed in tacho counts per second used when `speed_regulation` is on. Reading returns the current value.  Use the `count_per_rot` attribute to convert RPM or deg/sec to tacho counts per second.
+Ramp Up SP|int|Read/Write| Writing sets the ramp up setpoint. Reading returns the current value. Units are in milliseconds. When set to a value > 0, the motor will ramp the power sent to the motor from 0 to 100% duty cycle over the span of this setpoint when starting the motor. If the maximum duty cycle is limited by `duty_cycle_sp` or speed regulation, the actual ramp time duration will be less than the setpoint.
+Ramp Down SP|int|Read/Write| Writing sets the ramp down setpoint. Reading returns the current value. Units are in milliseconds. When set to a value > 0, the motor will ramp the power sent to the motor from 100% duty cycle down to 0 over the span of this setpoint when stopping the motor. If the starting duty cycle is less than 100%, the ramp time duration will be less than the full span of the setpoint.
+Speed Regulation Enabled|string|Read/Write| Turns speed regulation on or off. If speed regulation is on, the motor controller will vary the power supplied to the motor to try to maintain the speed specified in `speed_sp`. If speed regulation is off, the controller will use the power specified in `duty_cycle_sp`. Valid values are `on` and `off`.
+Speed Regulation P|int|Read/Write| The proportional constant for the speed regulation PID.
+Speed Regulation I|int|Read/Write| The integral constant for the speed regulation PID.
+Speed Regulation D|int|Read/Write| The derivative constant for the speed regulation PID.
+State|string array|Read| Reading returns a space separated list of state flags. Possible flags are `running`, `ramping` `holding` and `stalled`.
+Stop Command|string|Read/Write| Reading returns the current stop command. Writing sets the stop command. The value determines the motors behavior when `command` is set to `stop`. Also, it determines the motors behavior when a run command completes. See `stop_commands` for a list of possible values.
+Stop Commands|string array|Read| Returns a space-separated list of stop modes supported by the motor controller. Possible values are `coast`, `brake` and `hold`. `coast` means that power will be removed from the motor and it will freely coast to a stop. `brake` means that power will be removed from the motor and a passive electrical load will be placed on the motor. This is usually done by shorting the motor terminals together. This load will absorb the energy from the rotation of the motors and cause the motor to stop more quickly than coasting. `hold` does not remove power from the motor. Instead it actively try to hold the motor at the current position. If an external force tries to turn the motor, the motor will 'push back' to maintain its position.
+Time SP|int|Read/Write| Writing specifies the amount of time the motor will run when using the `run-timed` command. Reading returns the current value. Units are in milliseconds.
+
 
 <!-- ~autogen -->
 
@@ -81,6 +92,15 @@ Reset|Void|None|Sets the `command` motor property to `reset`, which causes the m
 
 `DC Motor` (class) : abstract "IO Device"
 -----
+
+<!-- ~autogen md_generic-class-description classes.dcMotor>currentClass -->
+
+The DC motor class provides a uniform interface for using regular DC motors
+with no fancy controls or feedback. This includes LEGO MINDSTORMS RCX motors
+and LEGO Power Functions motors.
+
+<!-- ~autogen -->
+
 ###Constructor:
 
 Argument Name|Type|Description
@@ -93,15 +113,19 @@ Port|String|The port to control. Specify a blank string (or the undefined/null v
 
 Property Name|Type|Accessibility|Description
 ---|---|---|---
-Command|string|Read/Write|
-Commands|string array|Read|
-Driver Name|string|Read|
-Duty Cycle|int|Read|
-Duty Cycle SP|int|Read/Write|
-Polarity|string|Read/Write|
-Port Name|string|Read|
-Ramp Down MS|int|Read/Write|
-Ramp Up MS|int|Read/Write|
+Command|string|Write| Sets the command for the motor. Possible values are `run-forever`, `run-timed` and `stop`. Not all commands may be supported, so be sure to check the contents of the `commands` attribute.
+Commands|string array|Read| Returns a space separated list of commands supported by the motor controller.
+Driver Name|string|Read| Returns the name of the motor driver that loaded this device. See the list of [supported devices] for a list of drivers.
+Duty Cycle|int|Read| Shows the current duty cycle of the PWM signal sent to the motor. Values are -100 to 100 (-100% to 100%).
+Duty Cycle SP|int|Read/Write| Writing sets the duty cycle setpoint of the PWM signal sent to the motor. Valid values are -100 to 100 (-100% to 100%). Reading returns the current setpoint.
+Polarity|string|Read/Write| Sets the polarity of the motor. Valid values are `normal` and `inverted`.
+Port Name|string|Read| Returns the name of the port that the motor is connected to.
+Ramp Down SP|int|Read/Write| Sets the time in milliseconds that it take the motor to ramp down from 100% to 0%. Valid values are 0 to 10000 (10 seconds). Default is 0.
+Ramp Up SP|int|Read/Write| Sets the time in milliseconds that it take the motor to up ramp from 0% to 100%. Valid values are 0 to 10000 (10 seconds). Default is 0.
+State|string array|Read| Gets a space separated list of flags indicating the motor status. Possible flags are `running` and `ramping`. `running` indicates that the motor is powered. `ramping` indicates that the motor has not yet reached the `duty_cycle_sp`.
+Stop Command|string|Write| Sets the stop command that will be used when the motor stops. Read `stop_commands` to get the list of valid values.
+Stop Commands|string array|Read| Gets a space separated list of stop commands. Valid values are `coast` and `brake`.
+
 
 <!-- ~autogen -->
 
@@ -116,6 +140,14 @@ Connected|Boolean|Read
 
 `Servo Motor` (class) : abstract "IO Device"
 -----
+
+<!-- ~autogen md_generic-class-description classes.servoMotor>currentClass -->
+
+The servo motor class provides a uniform interface for using hobby type
+servo motors.
+
+<!-- ~autogen -->
+
 ###Constructor:
 
 Argument Name|Type|Description
@@ -128,15 +160,17 @@ Port|String|The port to control. Specify a blank string (or the undefined/null v
 
 Property Name|Type|Accessibility|Description
 ---|---|---|---
-Command|string|Read/Write|
-Driver Name|string|Read|
-Max Pulse MS|int|Read/Write|
-Mid Pulse MS|int|Read/Write|
-Min Pulse MS|int|Read/Write|
-Polarity|string|Read/Write|
-Port Name|string|Read|
-Position|int|Read/Write|
-Rate|int|Read/Write|
+Command|string|Write| Sets the command for the servo. Valid values are `run` and `float`. Setting to `run` will cause the servo to be driven to the position_sp set in the `position_sp` attribute. Setting to `float` will remove power from the motor.
+Driver Name|string|Read| Returns the name of the motor driver that loaded this device. See the list of [supported devices] for a list of drivers.
+Max Pulse SP|int|Read/Write| Used to set the pulse size in milliseconds for the signal that tells the servo to drive to the maximum (clockwise) position_sp. Default value is 2400. Valid values are 2300 to 2700. You must write to the position_sp attribute for changes to this attribute to take effect.
+Mid Pulse SP|int|Read/Write| Used to set the pulse size in milliseconds for the signal that tells the servo to drive to the mid position_sp. Default value is 1500. Valid values are 1300 to 1700. For example, on a 180 degree servo, this would be 90 degrees. On continuous rotation servo, this is the 'neutral' position_sp where the motor does not turn. You must write to the position_sp attribute for changes to this attribute to take effect.
+Min Pulse SP|int|Read/Write| Used to set the pulse size in milliseconds for the signal that tells the servo to drive to the miniumum (counter-clockwise) position_sp. Default value is 600. Valid values are 300 to 700. You must write to the position_sp attribute for changes to this attribute to take effect.
+Polarity|string|Read/Write| Sets the polarity of the servo. Valid values are `normal` and `inverted`. Setting the value to `inverted` will cause the position_sp value to be inverted. i.e `-100` will correspond to `max_pulse_sp`, and `100` will correspond to `min_pulse_sp`.
+Port Name|string|Read| Returns the name of the port that the motor is connected to.
+Position SP|int|Read/Write| Reading returns the current position_sp of the servo. Writing instructs the servo to move to the specified position_sp. Units are percent. Valid values are -100 to 100 (-100% to 100%) where `-100` corresponds to `min_pulse_sp`, `0` corresponds to `mid_pulse_sp` and `100` corresponds to `max_pulse_sp`.
+Rate SP|int|Read/Write| Sets the rate_sp at which the servo travels from 0 to 100.0% (half of the full range of the servo). Units are in milliseconds. Example: Setting the rate_sp to 1000 means that it will take a 180 degree servo 2 second to move from 0 to 180 degrees. Note: Some servo controllers may not support this in which case reading and writing will fail with `-EOPNOTSUPP`. In continuous rotation servos, this value will affect the rate_sp at which the speed ramps up or down.
+State|string array|Read| Returns a space separated list of flags indicating the state of the servo. Possible values are: * `running`: Indicates that the motor is powered.
+
 
 <!-- ~autogen -->
 
@@ -164,15 +198,16 @@ Types|String Array|The types of sensors (device IDs) to allow. Leave the array e
 
 Property Name|Type|Accessibility|Description
 ---|---|---|---
-Command|string|Write|
-Commands|string array|Read|
-Decimals|int|Read|
-Driver Name|string|Read|
-Mode|string|Read/Write|
-Modes|string array|Read|
-Num Values|int|Read|
-Port Name|string|Read|
-Units|string|Read|
+Command|string|Write| Sends a command to the sensor.
+Commands|string array|Read| Returns a space separated list of the valid commands for the sensor. Returns -EOPNOTSUPP if no commands are supported.
+Decimals|int|Read| Returns the number of decimal places for the values in the `value<N>` attributes of the current mode.
+Driver Name|string|Read| Returns the name of the sensor device/driver. See the list of [supported sensors] for a complete list of drivers.
+Mode|string|Read/Write| Returns the current mode. Writing one of the values returned by `modes` sets the sensor to that mode.
+Modes|string array|Read| Returns a space separated list of the valid modes for the sensor.
+Num Values|int|Read| Returns the number of `value<N>` attributes that will return a valid value for the current mode.
+Port Name|string|Read| Returns the name of the port that the sensor is connected to, e.g. `ev3:in1`. I2C sensors also include the I2C address (decimal), e.g. `ev3:in1:i2c8`.
+Units|string|Read| Returns the units of the measured value for the current mode. May return empty string
+
 
 <!-- ~autogen -->
 
@@ -194,6 +229,13 @@ Get Float Value|Number (float)|Value Index : Number|Gets the value at the specif
 
 `I2C Sensor` (class) : extends `Sensor`
 -----
+
+<!-- ~autogen md_generic-class-description classes.i2cSensor>currentClass -->
+
+A generic interface to control I2C-type EV3 sensors.
+
+<!-- ~autogen -->
+
 ###Constructor:
 The constructor for the `I2C Sensor` class is the same as its parent's constructor
 (the `Sensor` class).
@@ -204,8 +246,9 @@ The constructor for the `I2C Sensor` class is the same as its parent's construct
 
 Property Name|Type|Accessibility|Description
 ---|---|---|---
-FW Version|string|Read|
-Poll MS|int|Read/Write|
+FW Version|string|Read| Returns the firmware version of the sensor if available. Currently only I2C/NXT sensors support this.
+Poll MS|int|Read/Write| Returns the polling period of the sensor in milliseconds. Writing sets the polling period. Setting to 0 disables polling. Minimum value is hard coded as 50 msec. Returns -EOPNOTSUPP if changing polling is not supported. Currently only I2C/NXT sensors support changing the polling period.
+
 
 <!-- ~autogen -->
 
@@ -213,6 +256,14 @@ Poll MS|int|Read/Write|
 
 `Power Supply` (class)
 -----
+
+<!-- ~autogen md_generic-class-description classes.powerSupply>currentClass -->
+
+A generic interface to read data from the system's power_supply class.
+Uses the built-in legoev3-battery if none is specified.
+
+<!-- ~autogen -->
+
 ###Constructor:
 
 Argument Name|Type|Description
@@ -225,12 +276,13 @@ Device (optional)|String|The name of the device to control (as listed in `/sys/c
 
 Property Name|Type|Accessibility|Description
 ---|---|---|---
-Measured Current|int|Read|The measured current that the battery is supplying (in microamps)
-Measured Voltage|int|Read|The measured voltage that the battery is supplying (in microvolts)
+Measured Current|int|Read| The measured current that the battery is supplying (in microamps)
+Measured Voltage|int|Read| The measured voltage that the battery is supplying (in microvolts)
 Max Voltage|int|Read|
 Min Voltage|int|Read|
 Technology|string|Read|
 Type|string|Read|
+
 
 <!-- ~autogen -->
 
@@ -248,6 +300,13 @@ Connected|Boolean|Read
 
 `LED` (class)
 -----
+
+<!-- ~autogen md_generic-class-description classes.led>currentClass -->
+
+Any device controlled by the generic LED driver.
+
+<!-- ~autogen -->
+
 ###Constructor:
 
 Argument Name|Type|Description
@@ -260,9 +319,10 @@ Device|String|The name of the device to control (as listed in `/sys/class/leds/`
 
 Property Name|Type|Accessibility|Description
 ---|---|---|---
-Max Brightness|int|Read|
-Brightness|int|Read/Write|
-Trigger|string|Read/Write|
+Max Brightness|int|Read| Gets the maximum allowable brightness value
+Brightness|int|Read/Write| Sets the brightness level. Possible values are from 0 to `max_brightness`.
+Trigger|string|Read/Write| Sets the led trigger.
+
 
 <!-- ~autogen -->
 


### PR DESCRIPTION
This adds class/property descriptions to `spec.json` and employs those for extending `wrapper-specification.md`, generating C++ comments for API functions, and generate python docstrings. The descriptions are copied from comments in [ev3dev/lego-linux-drivers](https://github.com/ev3dev/lego-linux-drivers).

The descriptions are specified in multiline format (as string lists) to allow for easy formatting of the generated code. The class descriptions are used to provide brief overview of each class in `wrapper-specification.md`.