### PR TITLE
[cpp] Suppress output of aplay command

### DIFF
--- a/cpp/ev3dev.cpp
+++ b/cpp/ev3dev.cpp
@@ -839,7 +839,7 @@ void sound::tone(unsigned frequency, unsigned ms)
 
 void sound::play(const std::string &soundfile, bool bSynchronous)
 {
-  std::string cmd("aplay ");
+  std::string cmd("aplay -q ");
   cmd.append(soundfile);
   if (!bSynchronous)
   {
@@ -855,7 +855,7 @@ void sound::speak(const std::string &text, bool bSynchronous)
 {
   std::string cmd("espeak -a 200 --stdout \"");
   cmd.append(text);
-  cmd.append("\" | aplay");
+  cmd.append("\" | aplay -q");
   if (!bSynchronous)
   {
     cmd.append(" &");


### PR DESCRIPTION
This adds `-q` flag to `aplay` call that is used for wav playback and for
`espeak` invocation. This suppresses the annoying output of `aplay` that
litters the ev3 screen.