### PR TITLE
[autogen][cpp][python] Added NXT sound and light sensors support

### DIFF
--- a/autogen/spec.json
+++ b/autogen/spec.json
@@ -743,6 +743,7 @@
             "description": [
                 "LEGO EV3 color sensor."
             ],
+            "docsLink": "http://www.ev3dev.org/docs/sensors/lego-ev3-color-sensor/",
             "systemClassName":  "lego-sensor",
             "systemDeviceNameConvention":  "sensor{0}",
             "inheritance": [
@@ -786,6 +787,7 @@
             "description": [
                 "LEGO EV3 ultrasonic sensor."
             ],
+            "docsLink": "http://www.ev3dev.org/docs/sensors/lego-ev3-ultrasonic-sensor/",
             "systemClassName":  "lego-sensor",
             "systemDeviceNameConvention":  "sensor{0}",
             "inheritance": [
@@ -833,6 +835,7 @@
             "description": [
                 "LEGO EV3 gyro sensor."
             ],
+            "docsLink": "http://www.ev3dev.org/docs/sensors/lego-ev3-gyro-sensor/",
             "systemClassName":  "lego-sensor",
             "systemDeviceNameConvention":  "sensor{0}",
             "inheritance": [
@@ -876,6 +879,7 @@
             "description": [
                 "LEGO EV3 infrared sensor."
             ],
+            "docsLink": "http://www.ev3dev.org/docs/sensors/lego-ev3-infrared-sensor/",
             "systemClassName":  "lego-sensor",
             "systemDeviceNameConvention":  "sensor{0}",
             "inheritance": [
@@ -908,6 +912,64 @@
                         { "name": "IR-CAL",
                             "description": [
                                 "Calibration ???"
+                            ]
+                        }
+                    ]
+                }
+            ]
+        },
+        "soundSensor": {
+            "friendlyName": "Sound Sensor",
+            "description": [
+                "LEGO NXT Sound Sensor"
+            ],
+            "docsLink": "http://www.ev3dev.org/docs/sensors/lego-nxt-sound-sensor/",
+            "systemClassName":  "lego-nxt-sound",
+            "systemDeviceNameConvention":  "sensor{0}",
+            "inheritance": [
+                "sensor"
+            ],
+            "propertyValues": [
+                {
+                    "propertyName": "Mode",
+                    "values": [
+                        { "name": "DB",
+                            "description": [
+                                "Sound pressure level. Flat weighting"
+                            ]
+                        },
+                        { "name": "DBA",
+                            "description": [
+                                "Sound pressure level. A weighting"
+                            ]
+                        }
+                    ]
+                }
+            ]
+        },
+        "lightSensor": {
+            "friendlyName": "Light Sensor",
+            "description": [
+                "LEGO NXT Light Sensor"
+            ],
+            "docsLink": "http://www.ev3dev.org/docs/sensors/lego-nxt-light-sensor/",
+            "systemClassName":  "lego-nxt-light",
+            "systemDeviceNameConvention":  "sensor{0}",
+            "inheritance": [
+                "sensor"
+            ],
+            "propertyValues": [
+                {
+                    "propertyName": "Mode",
+                    "values": [
+                        { "name": "REFLECT",
+                            "description": [
+                                "Reflected light. LED on"
+                            ]
+                        },
+                        { "name": "AMBIENT",
+                            "description": [
+                                "Ambient light. LED off"
                             ]
                         }
                     ]

--- a/cpp/ev3dev.cpp
+++ b/cpp/ev3dev.cpp
@@ -439,6 +439,7 @@ const sensor::sensor_type sensor::nxt_light       { "lego-nxt-light" };
 const sensor::sensor_type sensor::nxt_sound       { "lego-nxt-sound" };
 const sensor::sensor_type sensor::nxt_ultrasonic  { "lego-nxt-us" };
 const sensor::sensor_type sensor::nxt_i2c_sensor  { "nxt-i2c-sensor" };
+const sensor::sensor_type sensor::nxt_analog      { "nxt-analog" };
 
 //-----------------------------------------------------------------------------
 
@@ -615,6 +616,49 @@ const std::string infrared_sensor::mode_ir_cal{ "IR-CAL" };
 
 infrared_sensor::infrared_sensor(port_type port_) :
   sensor(port_, { ev3_infrared })
+{
+}
+
+//-----------------------------------------------------------------------------
+
+//~autogen cpp_generic-define-property-value classes.soundSensor>currentClass
+
+const std::string sound_sensor::mode_db{ "DB" };
+const std::string sound_sensor::mode_dba{ "DBA" };
+
+//~autogen
+
+sound_sensor::sound_sensor(port_type port_) :
+  sensor(port_, { nxt_sound, nxt_analog })
+{
+    if (connected() && driver_name() == nxt_analog) {
+        device port;
+        port.connect(SYS_ROOT "/class/lego-port/", "port", {{"port_name", {port_name()}}});
+
+        if (port.connected()) {
+            port.set_attr_string("set_device", nxt_sound);
+
+            if (port.get_attr_string("status") != nxt_sound) {
+                // Failed to load lego-nxt-sound friver. Wrong port?
+                _path.clear();
+            }
+        } else {
+            _path.clear();
+        }
+    }
+}
+
+//-----------------------------------------------------------------------------
+
+//~autogen cpp_generic-define-property-value classes.lightSensor>currentClass
+
+const std::string light_sensor::mode_reflect{ "REFLECT" };
+const std::string light_sensor::mode_ambient{ "AMBIENT" };
+
+//~autogen
+
+light_sensor::light_sensor(port_type port_) :
+  sensor(port_, { nxt_light })
 {
 }
 

--- a/cpp/ev3dev.cpp
+++ b/cpp/ev3dev.cpp
@@ -45,6 +45,7 @@
 #include <sys/mman.h>
 #include <fcntl.h>
 #include <stdlib.h>
+#include <errno.h>
 
 #ifndef SYS_ROOT
 #define SYS_ROOT "/sys"
@@ -288,7 +289,7 @@ void device::set_attr_int(const std::string &name, int value)
   ofstream &os = ofstream_open(_path + name);
   if (os.is_open())
   {
-    os << value;
+    if (!(os << value)) throw system_error(std::error_code(errno, std::system_category()));
     return;
   }
 
@@ -327,7 +328,7 @@ void device::set_attr_string(const std::string &name, const std::string &value)
   ofstream &os = ofstream_open(_path + name);
   if (os.is_open())
   {
-    os << value;
+    if (!(os << value)) throw system_error(std::error_code(errno, std::system_category()));
     return;
   }
 

--- a/cpp/ev3dev.h
+++ b/cpp/ev3dev.h
@@ -131,6 +131,7 @@ public:
   static const sensor_type nxt_sound;
   static const sensor_type nxt_ultrasonic;
   static const sensor_type nxt_i2c_sensor;
+  static const sensor_type nxt_analog;
 
   sensor(port_type);
   sensor(port_type, const std::set<sensor_type>&);
@@ -386,6 +387,54 @@ public:
 
   // Calibration ???
   static const std::string mode_ir_cal;
+
+
+//~autogen
+};
+
+//-----------------------------------------------------------------------------
+
+//~autogen cpp_generic-class-description classes.soundSensor>currentClass
+
+// LEGO NXT Sound Sensor
+
+//~autogen
+class sound_sensor : public sensor
+{
+public:
+  sound_sensor(port_type port_ = INPUT_AUTO);
+
+  //~autogen cpp_generic-declare-property-value classes.soundSensor>currentClass
+
+  // Sound pressure level. Flat weighting
+  static const std::string mode_db;
+
+  // Sound pressure level. A weighting
+  static const std::string mode_dba;
+
+
+//~autogen
+};
+
+//-----------------------------------------------------------------------------
+
+//~autogen cpp_generic-class-description classes.lightSensor>currentClass
+
+// LEGO NXT Light Sensor
+
+//~autogen
+class light_sensor : public sensor
+{
+public:
+  light_sensor(port_type port_ = INPUT_AUTO);
+
+  //~autogen cpp_generic-declare-property-value classes.lightSensor>currentClass
+
+  // Reflected light. LED on
+  static const std::string mode_reflect;
+
+  // Ambient light. LED off
+  static const std::string mode_ambient;
 
 
 //~autogen


### PR DESCRIPTION
The sound sensor tries to connect to a port with either `lego-nxt-sound` or `nxt-analog` driver. In case the driver is `nxt-analog`, it tries to load the correct driver through the corresponding `lego-port` class.

See the fine print here: http://www.ev3dev.org/docs/sensors/#fn:nxt-analog

Refs #59

@WasabiFan, I am not sure if this should be merged now or after the stable release, so I leave the decision to you.