### PR TITLE
[cpp] Fix a bug in sensor.bin_data()

### DIFF
--- a/cpp/ev3dev.cpp
+++ b/cpp/ev3dev.cpp
@@ -556,7 +556,7 @@ const std::vector<char>& sensor::bin_data() const
     _bin_data.resize(num_values() * value_size);
   }
 
-  static const string fname = _path + "bin_data";
+  const string fname = _path + "bin_data";
   ifstream &is = ifstream_open(fname);
   if (is.is_open())
   {


### PR DESCRIPTION
Path to the sensor attribute was erroneously decorated with `static` keyword, which lead to all sensors sharing same attribute. Sorry about that.