### PR TITLE
[spec] Extends specification of LED class

### DIFF
--- a/autogen/spec.json
+++ b/autogen/spec.json
@@ -614,13 +614,15 @@
         "led": {
             "friendlyName": "LED",
             "description": [
-                "Any device controlled by the generic LED driver."
+                "Any device controlled by the generic LED driver.",
+                "See https://www.kernel.org/doc/Documentation/leds/leds-class.txt",
+                "for more details."
             ],
             "systemClassName":  "leds",
             "systemProperties": [
                 { "name": "Max Brightness", "systemName": "max_brightness", "type": "int", "readAccess": true, "writeAccess": false,
                   "description": [
-                      "Gets the maximum allowable brightness value"
+                      "Returns the maximum allowable brightness value."
                   ]
                 },
                 { "name": "Brightness", "systemName": "brightness", "type": "int", "readAccess": true, "writeAccess": true,
@@ -628,9 +630,41 @@
                       "Sets the brightness level. Possible values are from 0 to `max_brightness`."
                   ]
                 },
+                { "name": "Triggers", "systemName": "triggers", "type": "string array", "readAccess": true, "writeAccess": false,
+                  "description": [
+                      "Returns a list of available triggers."
+                  ]
+                },
                 { "name": "Trigger", "systemName": "trigger", "type": "string", "readAccess": true, "writeAccess": true,
                   "description": [
-                      "Sets the led trigger."
+                      "Sets the led trigger. A trigger",
+                      "is a kernel based source of led events. Triggers can either be simple or",
+                      "complex. A simple trigger isn't configurable and is designed to slot into",
+                      "existing subsystems with minimal additional code. Examples are the `ide-disk` and",
+                      "`nand-disk` triggers.",
+                      "",
+                      "Complex triggers whilst available to all LEDs have LED specific",
+                      "parameters and work on a per LED basis. The `timer` trigger is an example.",
+                      "The `timer` trigger will periodically change the LED brightness between",
+                      "0 and the current brightness setting. The `on` and `off` time can",
+                      "be specified via `delay_{on,off}` attributes in milliseconds.",
+                      "You can change the brightness value of a LED independently of the timer",
+                      "trigger. However, if you set the brightness value to 0 it will",
+                      "also disable the `timer` trigger."
+                  ]
+                },
+                { "name": "Delay On", "systemName": "delay_on", "type": "int", "readAccess": true, "writeAccess": true,
+                  "description": [
+                      "The `timer` trigger will periodically change the LED brightness between",
+                      "0 and the current brightness setting. The `on` time can",
+                      "be specified via `delay_on` attribute in milliseconds."
+                  ]
+                },
+                { "name": "Delay Off", "systemName": "delay_off", "type": "int", "readAccess": true, "writeAccess": true,
+                  "description": [
+                      "The `timer` trigger will periodically change the LED brightness between",
+                      "0 and the current brightness setting. The `off` time can",
+                      "be specified via `delay_off` attribute in milliseconds."
                   ]
                 }
             ]

--- a/wrapper-specification.md
+++ b/wrapper-specification.md
@@ -342,10 +342,35 @@ Delay Off|int|Read/Write| The `timer` trigger will periodically change the LED b
 Property Name|Type|Accessibility|Description
 ---|---|---|---
 Connected|Boolean|Read
-Red Right|LED|Read/Write|EV3 red right LED
-Red Left|LED|Read/Write|EV3 red left LED
-Green Right|LED|Read/Write|EV3 green green LED
-Green Left|LED|Read/Write|EV3 green left LED
+
+###Methods
+
+Method name | Return type | Arguments | Description
+---|---|---|---
+On    | void | None | Turns the led on by setting its brightness to the maximum level.
+Off   | void | None | Turns the led off.
+Flash | void | ON interval: Number, OFF interval: Number | Enables `timer` trigger and sets `delay_on` and `delay_off` attributes to the provided values (in milliseconds).
+
+###Static methods
+
+Method name | Return type | Arguments | Description
+---|---|---|---
+Red On    | void | None | Turns both red leds on.
+Red Off   | void | None | Turns both red leds off.
+Green On  | void | None | Turns both green leds on.
+Green Off | void | None | Turns both green leds off.
+All On    | void | None | Turns all leds on.
+All Off   | void | None | Turns all leds off.
+
+###Predefined instances
+
+There are four predefined instances of the LED class corresponding to the EV3
+leds:
+
+* Red Right
+* Red Left
+* Green Right
+* Green Left
 
 <hr/>
 

--- a/wrapper-specification.md
+++ b/wrapper-specification.md
@@ -310,6 +310,8 @@ Connected|Boolean|Read
 <!-- ~autogen md_generic-class-description classes.led>currentClass -->
 
 Any device controlled by the generic LED driver.
+See https://www.kernel.org/doc/Documentation/leds/leds-class.txt
+for more details.
 
 <!-- ~autogen -->
 
@@ -325,9 +327,12 @@ Device|String|The name of the device to control (as listed in `/sys/class/leds/`
 
 Property Name|Type|Accessibility|Description
 ---|---|---|---
-Max Brightness|int|Read| Gets the maximum allowable brightness value
+Max Brightness|int|Read| Returns the maximum allowable brightness value.
 Brightness|int|Read/Write| Sets the brightness level. Possible values are from 0 to `max_brightness`.
-Trigger|string|Read/Write| Sets the led trigger.
+Triggers|string array|Read| Returns a list of available triggers.
+Trigger|string|Read/Write| Sets the led trigger. A trigger is a kernel based source of led events. Triggers can either be simple or complex. A simple trigger isn't configurable and is designed to slot into existing subsystems with minimal additional code. Examples are the `ide-disk` and `nand-disk` triggers.  Complex triggers whilst available to all LEDs have LED specific parameters and work on a per LED basis. The `timer` trigger is an example. The `timer` trigger will periodically change the LED brightness between 0 and the current brightness setting. The `on` and `off` time can be specified via `delay_{on,off}` attributes in milliseconds. You can change the brightness value of a LED independently of the timer trigger. However, if you set the brightness value to 0 it will also disable the `timer` trigger.
+Delay On|int|Read/Write| The `timer` trigger will periodically change the LED brightness between 0 and the current brightness setting. The `on` time can be specified via `delay_on` attribute in milliseconds.
+Delay Off|int|Read/Write| The `timer` trigger will periodically change the LED brightness between 0 and the current brightness setting. The `off` time can be specified via `delay_off` attribute in milliseconds.
 
 
 <!-- ~autogen -->
@@ -337,6 +342,10 @@ Trigger|string|Read/Write| Sets the led trigger.
 Property Name|Type|Accessibility|Description
 ---|---|---|---
 Connected|Boolean|Read
+Red Right|LED|Read/Write|EV3 red right LED
+Red Left|LED|Read/Write|EV3 red left LED
+Green Right|LED|Read/Write|EV3 green green LED
+Green Left|LED|Read/Write|EV3 green left LED
 
 <hr/>
 


### PR DESCRIPTION
- Improved documentation of `trigger` attribute.
- Added description of `delay_{on,off}` attributes.
- Added the four of EV3 leds as special properties.

I am not sure that the four EV3 leds should go into `special properties` section though. Those are static class members in C++, and they could be called properties in python. Also, there are no other preexisting suitable sections in `wrapper-specification.md`. @WasabiFan, what do you think?

There are other [convenience methods](https://github.com/ev3dev/ev3dev-lang/blob/1cb94fe6643a6bdcb28e937f2be5358ebd6cb579/cpp/ev3dev.h#L1238-L1265) in C++ API, which are implemented in terms of the documented sysfs attributes. These are `on`/`off` methods, `flash` method, and a family of `*_on`/`*_off` static methods that control groups of leds (e.g. `red_on`, `all_off`). Should those be in the specification?
