### PR TITLE
Fix led trigger specification

### DIFF
--- a/autogen/spec.json
+++ b/autogen/spec.json
@@ -630,12 +630,12 @@
                       "Sets the brightness level. Possible values are from 0 to `max_brightness`."
                   ]
                 },
-                { "name": "Triggers", "systemName": "triggers", "type": "string array", "readAccess": true, "writeAccess": false,
+                { "name": "Triggers", "systemName": "trigger", "type": "string array", "readAccess": true, "writeAccess": false,
                   "description": [
                       "Returns a list of available triggers."
                   ]
                 },
-                { "name": "Trigger", "systemName": "trigger", "type": "string", "readAccess": true, "writeAccess": true,
+                { "name": "Trigger", "systemName": "trigger", "type": "string selector", "readAccess": true, "writeAccess": true,
                   "description": [
                       "Sets the led trigger. A trigger",
                       "is a kernel based source of led events. Triggers can either be simple or",

--- a/autogen/templates/cpp_generic-get-set.liquid
+++ b/autogen/templates/cpp_generic-get-set.liquid
@@ -10,22 +10,26 @@
   // {{ line }}{%
   endfor %}{%
   assign cppName = prop.name | downcase | underscore_spaces %}{%
-  if prop.type contains 'array' %}
-  mode_set {{ cppName }}() const { return get_attr_set("{{ prop.systemName }}"); }{%
-  else %}{%
-    assign type = prop.type %}{%
-    assign attr = type %}{%
-    if type == 'string' %}{%
-      assign type = 'std::string' %}{%
-    endif %}{%
-    if prop.readAccess == true %}
-  {{ type }} {{ cppName }}() const { return get_attr_{{ attr }}("{{ prop.systemName }}"); }{%
-    endif %}{%
-    if prop.writeAccess == true %}
+  assign type   = prop.type %}{%
+  assign getter = prop.type %}{%
+  assign setter = prop.type %}{%
+  if prop.type == 'string' %}{%
+    assign type  = 'std::string' %}{%
+  elsif prop.type == 'string array' %}{%
+    assign type  = 'mode_set' %}{%
+    assign getter = 'set' %}{%
+  elsif prop.type == 'string selector' %}{%
+    assign type  = 'std::string' %}{%
+    assign getter = 'from_set' %}{%
+    assign setter = 'string' %}{%
+  endif %}{%
+  if prop.readAccess == true %}
+  {{ type }} {{ cppName }}() const { return get_attr_{{ getter }}("{{ prop.systemName }}"); }{%
+  endif %}{%
+  if prop.writeAccess == true %}
   auto set_{{ cppName }}({{ type }} v) -> decltype(*this) {
-    set_attr_{{ attr }}("{{ prop.systemName }}", v);
+    set_attr_{{ setter }}("{{ prop.systemName }}", v);
     return *this;
   }{%
-    endif %}{%
   endif %}
 {%endfor %}

--- a/cpp/ev3dev.h
+++ b/cpp/ev3dev.h
@@ -1226,7 +1226,7 @@ public:
 
   // Triggers: read-only
   // Returns a list of available triggers.
-  mode_set triggers() const { return get_attr_set("triggers"); }
+  mode_set triggers() const { return get_attr_set("trigger"); }
 
   // Trigger: read/write
   // Sets the led trigger. A trigger
@@ -1243,7 +1243,7 @@ public:
   // You can change the brightness value of a LED independently of the timer
   // trigger. However, if you set the brightness value to 0 it will
   // also disable the `timer` trigger.
-  std::string trigger() const { return get_attr_string("trigger"); }
+  std::string trigger() const { return get_attr_from_set("trigger"); }
   auto set_trigger(std::string v) -> decltype(*this) {
     set_attr_string("trigger", v);
     return *this;

--- a/wrapper-specification.md
+++ b/wrapper-specification.md
@@ -17,6 +17,14 @@ Implementation Notes (important)
 - File access. There should be one class that is used or inherited from in all other classes that need to access object properties via file I/O. This class should check paths for validity, do basic error checking, and generally implement as much of the core I/O functionality as possible.
 - Errors. All file access and other error-prone calls should be wrapped with error handling. If an error thrown by an external call is fatal, the wrapper should throw an error for the caller that states the error and gives some insight in to what actually happened.
 - Naming conventions. All names should follow the language's naming conventions. Keep the names consistent, so that users can easily find what they want.
+- Attribute types. `int` and `string` attributes are read-write files
+  containing a single value that is representable either as an integer or as a
+  single word. A `string array` attribute is a readonly file that contains
+  space-separated list of words, where each word is a possible value of some
+  other `string` atribute.  And a `string selector` attribute is a read-write
+  file that contains space-separated list of possible values, where the
+  currently selected value is enclosed in square brackets. Another value may be
+  selected by writing a single word to a file.
 
 <hr/>
 
@@ -330,7 +338,7 @@ Property Name|Type|Accessibility|Description
 Max Brightness|int|Read| Returns the maximum allowable brightness value.
 Brightness|int|Read/Write| Sets the brightness level. Possible values are from 0 to `max_brightness`.
 Triggers|string array|Read| Returns a list of available triggers.
-Trigger|string|Read/Write| Sets the led trigger. A trigger is a kernel based source of led events. Triggers can either be simple or complex. A simple trigger isn't configurable and is designed to slot into existing subsystems with minimal additional code. Examples are the `ide-disk` and `nand-disk` triggers.  Complex triggers whilst available to all LEDs have LED specific parameters and work on a per LED basis. The `timer` trigger is an example. The `timer` trigger will periodically change the LED brightness between 0 and the current brightness setting. The `on` and `off` time can be specified via `delay_{on,off}` attributes in milliseconds. You can change the brightness value of a LED independently of the timer trigger. However, if you set the brightness value to 0 it will also disable the `timer` trigger.
+Trigger|string selector|Read/Write| Sets the led trigger. A trigger is a kernel based source of led events. Triggers can either be simple or complex. A simple trigger isn't configurable and is designed to slot into existing subsystems with minimal additional code. Examples are the `ide-disk` and `nand-disk` triggers.  Complex triggers whilst available to all LEDs have LED specific parameters and work on a per LED basis. The `timer` trigger is an example. The `timer` trigger will periodically change the LED brightness between 0 and the current brightness setting. The `on` and `off` time can be specified via `delay_{on,off}` attributes in milliseconds. You can change the brightness value of a LED independently of the timer trigger. However, if you set the brightness value to 0 it will also disable the `timer` trigger.
 Delay On|int|Read/Write| The `timer` trigger will periodically change the LED brightness between 0 and the current brightness setting. The `on` time can be specified via `delay_on` attribute in milliseconds.
 Delay Off|int|Read/Write| The `timer` trigger will periodically change the LED brightness between 0 and the current brightness setting. The `off` time can be specified via `delay_off` attribute in milliseconds.
 


### PR DESCRIPTION
This fixes specification of `led::trigger` attribute as discussed in #98.
Also, the C++ template is altered to mirror the change, and possible attribute types are described in wrapper-specification.md.
