### PR TITLE
[spec] Fix an issue with led groups on BrickPi

### DIFF
--- a/autogen/spec.json
+++ b/autogen/spec.json
@@ -1228,8 +1228,8 @@
                     { "name" : "Blue Two", "systemName": "brickpi2:blue:ev3dev" }
                 ],
                 "groups" : [
-                    { "name" : "Blue One", "entries" : ["Blue One"] },
-                    { "name" : "Blue Two", "entries" : ["Blue Two"] }
+                    { "name" : "One", "entries" : ["Blue One"] },
+                    { "name" : "Two", "entries" : ["Blue Two"] }
                 ],
                 "colors": [
                     { "name" : "Blue", "value" : [ 1.0 ] }


### PR DESCRIPTION
I was updating C++ bindings and noticed that led instance names on
BrickPi coincide with group names. This is not an issue for python since
group names are capitalized there by convention. This is a problem for
C++ though, where everything is lower case.

I'd like to rename group names on BrickPI:

```
'Blue One' -> 'One'
'Blue Two' -> 'Two'
```

This will affect other bindings, so waiting approval from @rhempel and @WasabiFan.
