### PR TITLE
spec.json: fix leds "triggers" system name.

### DIFF
--- a/autogen/spec.json
+++ b/autogen/spec.json
@@ -665,7 +665,7 @@
                       "Sets the brightness level. Possible values are from 0 to `max_brightness`."
                   ]
                 },
-                { "name": "Triggers", "systemName": "trigger", "type": "string array", "readAccess": true, "writeAccess": false,
+                { "name": "Triggers", "systemName": "triggers", "type": "string array", "readAccess": true, "writeAccess": false,
                   "description": [
                       "Returns a list of available triggers."
                   ]


### PR DESCRIPTION
Looks like there was a typo in the systemName for LEDs Triggers. This caused a clash in bindings I'm trying to generate.
