### PR TITLE
Since the 2015-12-30 image address is used in stead of port_name

### DIFF
--- a/wrapper-specification.md
+++ b/wrapper-specification.md
@@ -409,9 +409,9 @@ appropriate for the connected sensor. The `set_device` attribute is used to
 specify the exact type of sensor that is connected. Note: the mode must be
 correctly set before setting the sensor type.
 
-Ports can be found at `/sys/class/lego-port/port<N>` where `<N>` is
+Ports can be found at `/sys/class/lego-port/port<N>` where `<N>` may be
 incremented each time a new port is registered. Note: The number is not
-related to the actual port at all - use the `port_name` attribute to find
+related to the actual port at all - use the `address` attribute to find
 a specific port.
 
 <!-- ~autogen -->


### PR DESCRIPTION
Since the 2015-12-30 image the lego/port<N> is no longer incremented. 
It might be done in the future, so I left the increment in this doc.
I am not sure if this spec is auto-generated and if so I do not know where it came from .. .. ..
