### PR TITLE
Changes to support -ckt10+ kernels

### DIFF
--- a/spec.json
+++ b/spec.json
@@ -1,12 +1,12 @@
 {
     "meta": {
-        "version": "1.1.0",
+        "version": "1.2.0",
         "specRevision": 0,
         "supportedKernel": {
             "pattern": "{upstream_version}-{kernel}-{flavour}",
             "kernels": [
-                "10-ev3dev",
-                "10-rc1-ev3dev"
+                "11-ev3dev",
+                "11-rc1-ev3dev"
                 ]
             }
     },
@@ -92,15 +92,6 @@
                       "Writing sets the duty cycle setpoint. Reading returns the current value.",
                       "Units are in percent. Valid values are -100 to 100. A negative value causes",
                       "the motor to rotate in reverse."
-                  ]
-                },
-                { "name": "Encoder Polarity", "systemName": "encoder_polarity", "type": "string", "readAccess": true, "writeAccess": true,
-                  "description": [
-                      "Sets the polarity of the rotary encoder. This is an advanced feature to all",
-                      "use of motors that send inversed encoder signals to the EV3. This should",
-                      "be set correctly by the driver of a device. It You only need to change this",
-                      "value if you are using a unsupported device. Valid values are `normal` and",
-                      "`inversed`."
                   ]
                 },
                 { "name": "Full Travel Count", "systemName": "full_travel_count", "type": "int", "readAccess": true, "writeAccess": false,
@@ -212,24 +203,24 @@
                       "`running`, `ramping` `holding` and `stalled`."
                   ]
                 },
-                { "name": "Stop Command", "systemName": "stop_command", "type": "string", "readAccess": true, "writeAccess": true,
+                { "name": "Stop Action", "systemName": "stop_action", "type": "string", "readAccess": true, "writeAccess": true,
                   "description": [
-                      "Reading returns the current stop command. Writing sets the stop command.",
+                      "Reading returns the current stop action. Writing sets the stop action.",
                       "The value determines the motors behavior when `command` is set to `stop`.",
                       "Also, it determines the motors behavior when a run command completes. See",
-                      "`stop_commands` for a list of possible values."
+                      "`stop_actions` for a list of possible values."
                   ]
                 },
-                { "name": "Stop Commands", "systemName": "stop_commands", "type": "string array", "readAccess": true, "writeAccess": false,
+                { "name": "Stop Actions", "systemName": "stop_actions", "type": "string array", "readAccess": true, "writeAccess": false,
                   "description": [
-                      "Returns a list of stop modes supported by the motor controller.",
+                      "Returns a list of stop actions supported by the motor controller.",
                       "Possible values are `coast`, `brake` and `hold`. `coast` means that power will",
                       "be removed from the motor and it will freely coast to a stop. `brake` means",
                       "that power will be removed from the motor and a passive electrical load will",
                       "be placed on the motor. This is usually done by shorting the motor terminals",
                       "together. This load will absorb the energy from the rotation of the motors and",
                       "cause the motor to stop more quickly than coasting. `hold` does not remove",
-                      "power from the motor. Instead it actively try to hold the motor at the current",
+                      "power from the motor. Instead it actively tries to hold the motor at the current",
                       "position. If an external force tries to turn the motor, the motor will 'push",
                       "back' to maintain its position."
                   ]


### PR DESCRIPTION
- Removal of encoder_polarity attribute (tacho motor class)
- Rename of stop_command to stop_action (both tacho motor class and dc motor class)
- Rename of stop_commands to stop_actions (both tacho motor class and dc motor class)
