### PR TITLE
Return raw color values in a tuple from ColorSensor.raw()

### DIFF
--- a/spec.json
+++ b/spec.json
@@ -1103,6 +1103,15 @@
                     ]
                 },
                 {
+                    "name": "Raw",
+                    "sourceValue": [0, 1, 2],
+                    "type": ["int", "int", "int"],
+                    "requiredMode": "RGB-RAW",
+                    "description": [
+                        "Red, green, and blue components of the detected color, in the range 0-1020."
+                    ]
+                },
+                {
                     "name": "Red",
                     "sourceValue": [0],
                     "type": ["int"],


### PR DESCRIPTION
This is based on #169.

Makes possible to write

``` py
r,g,b = cs.raw()
```

instead of

``` py
r,g,b = cs.red(), cs.green(), cs.blue()
```

I am leaving `red()`, `green()`, and `blue()` in place, but we could also think about removing those completely.
